### PR TITLE
TEST-4  Add full test coverage for JwtAuthenticationFilter

### DIFF
--- a/src/test/java/com/f5/buzon_inteligente_BE/security/JwtAuthenticationFilterTest.java
+++ b/src/test/java/com/f5/buzon_inteligente_BE/security/JwtAuthenticationFilterTest.java
@@ -111,6 +111,23 @@ public class JwtAuthenticationFilterTest {
         assert(SecurityContextHolder.getContext().getAuthentication() == null);
     }
 
+    @Test
+    @DisplayName("Should handle exception and continue filter chain")
+    void shouldHandleExceptionAndContinueFilterChain() throws ServletException, IOException {
+        String token = "jwt-token";
+
+        when(jwtUtils.getJwtFromHeader(request)).thenReturn(token);
+        when(jwtUtils.validateJwtToken(token)).thenThrow(new RuntimeException("Unexpected error"));
+
+        jwtAuthenticationFilter.doFilterInternal(request, response, filterChain);
+
+        verify(jwtUtils).getJwtFromHeader(request);
+        verify(jwtUtils).validateJwtToken(token);
+        verify(filterChain).doFilter(request, response);
+
+        assert(SecurityContextHolder.getContext().getAuthentication() == null);
+    }
+
     
     
 }

--- a/src/test/java/com/f5/buzon_inteligente_BE/security/JwtAuthenticationFilterTest.java
+++ b/src/test/java/com/f5/buzon_inteligente_BE/security/JwtAuthenticationFilterTest.java
@@ -1,5 +1,6 @@
 package com.f5.buzon_inteligente_BE.security;
 
+import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.Mockito.*;
 
 import org.junit.jupiter.api.BeforeEach;
@@ -8,6 +9,7 @@ import org.junit.jupiter.api.Test;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.security.core.userdetails.UserDetailsService;
@@ -37,7 +39,7 @@ public class JwtAuthenticationFilterTest {
     private FilterChain filterChain;
 
     @Mock
-    private UserDetails userdetails;
+    private UserDetails userDetails;
 
     @InjectMocks
     private JwtAuthenticationFilter jwtAuthenticationFilter;
@@ -60,6 +62,35 @@ public class JwtAuthenticationFilterTest {
         verify(userDetailsService, never()).loadUserByUsername(any());
         verify(filterChain).doFilter(request, response);
         assert(SecurityContextHolder.getContext().getAuthentication() == null);
+    }
+
+    @Test
+    @DisplayName("Should authenticate user when JWT is valid")
+    void shouldAuthenticateWhenJwtIsValid() throws ServletException, IOException {
+        String token = "valid-jwt";
+        String username = "testUser";
+
+        when(jwtUtils.getJwtFromHeader(request)).thenReturn(token);
+        when(jwtUtils.validateJwtToken(token)).thenReturn(true);
+        when(jwtUtils.getUserNameFromJwtToken(token)).thenReturn(username);
+        when(userDetailsService.loadUserByUsername(username)).thenReturn(userDetails);
+        when(userDetails.getAuthorities()).thenReturn(java.util.Collections.emptyList());
+        when(request.getRemoteAddr()).thenReturn("127.0.0.1");
+        when(request.getSession(false)).thenReturn(null);
+
+        jwtAuthenticationFilter.doFilterInternal(request, response, filterChain);
+
+        verify(jwtUtils).getJwtFromHeader(request);
+        verify(jwtUtils).validateJwtToken(token);
+        verify(jwtUtils).getUserNameFromJwtToken(token);
+        verify(userDetailsService).loadUserByUsername(username);
+        verify(filterChain).doFilter(request, response);
+
+        var authentication = SecurityContextHolder.getContext().getAuthentication();
+        assert(authentication != null);
+        assert(authentication instanceof UsernamePasswordAuthenticationToken);
+        assert(authentication.getPrincipal().equals(userDetails));
+        assert(authentication.getAuthorities().isEmpty());
     }
 
     

--- a/src/test/java/com/f5/buzon_inteligente_BE/security/JwtAuthenticationFilterTest.java
+++ b/src/test/java/com/f5/buzon_inteligente_BE/security/JwtAuthenticationFilterTest.java
@@ -23,6 +23,7 @@ import java.io.IOException;
 
 @DisplayName("JwtAuthenticationFilterTest")
 public class JwtAuthenticationFilterTest {
+
     @Mock
     private JwtUtils jwtUtils;
 
@@ -44,16 +45,21 @@ public class JwtAuthenticationFilterTest {
     @InjectMocks
     private JwtAuthenticationFilter jwtAuthenticationFilter;
 
+    private String token;
+    private String username;
+
     @BeforeEach
     void setUp() {
         MockitoAnnotations.openMocks(this);
-        SecurityContextHolder.clearContext();        
+        SecurityContextHolder.clearContext();
+
+        token = "jwt-token";
+        username = "testUser";
     }
 
     @Test
     @DisplayName("Should not authenticate when token is missing")
     void testShouldNotAuthenticateWhenJwtIsMissing() throws ServletException, IOException {
-       
         when(jwtUtils.getJwtFromHeader(request)).thenReturn(null);
 
         jwtAuthenticationFilter.doFilterInternal(request, response, filterChain);
@@ -67,9 +73,6 @@ public class JwtAuthenticationFilterTest {
     @Test
     @DisplayName("Should authenticate user when JWT is valid")
     void shouldAuthenticateWhenJwtIsValid() throws ServletException, IOException {
-        String token = "valid-jwt";
-        String username = "testUser";
-
         when(jwtUtils.getJwtFromHeader(request)).thenReturn(token);
         when(jwtUtils.validateJwtToken(token)).thenReturn(true);
         when(jwtUtils.getUserNameFromJwtToken(token)).thenReturn(username);
@@ -96,8 +99,6 @@ public class JwtAuthenticationFilterTest {
     @Test
     @DisplayName("Should not authenticate user when JWT is invalid")
     void shouldNotAuthenticateWhenJwtIsInvalid() throws ServletException, IOException {
-        String token = "invalid-jwt";
-
         when(jwtUtils.getJwtFromHeader(request)).thenReturn(token);
         when(jwtUtils.validateJwtToken(token)).thenReturn(false);
 
@@ -114,8 +115,6 @@ public class JwtAuthenticationFilterTest {
     @Test
     @DisplayName("Should handle exception and continue filter chain")
     void shouldHandleExceptionAndContinueFilterChain() throws ServletException, IOException {
-        String token = "jwt-token";
-
         when(jwtUtils.getJwtFromHeader(request)).thenReturn(token);
         when(jwtUtils.validateJwtToken(token)).thenThrow(new RuntimeException("Unexpected error"));
 
@@ -127,7 +126,5 @@ public class JwtAuthenticationFilterTest {
 
         assert(SecurityContextHolder.getContext().getAuthentication() == null);
     }
-
-    
-    
 }
+

--- a/src/test/java/com/f5/buzon_inteligente_BE/security/JwtAuthenticationFilterTest.java
+++ b/src/test/java/com/f5/buzon_inteligente_BE/security/JwtAuthenticationFilterTest.java
@@ -1,7 +1,10 @@
 package com.f5.buzon_inteligente_BE.security;
 
+import static org.mockito.Mockito.*;
+
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
@@ -12,6 +15,8 @@ import org.springframework.security.core.userdetails.UserDetailsService;
 import jakarta.servlet.FilterChain;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
+import jakarta.servlet.ServletException;
+import java.io.IOException;
 
 
 @DisplayName("JwtAuthenticationFilterTest")
@@ -43,6 +48,20 @@ public class JwtAuthenticationFilterTest {
         SecurityContextHolder.clearContext();        
     }
 
-    
+    @Test
+    @DisplayName("Should not authenticate when token is missing")
+    void testShouldNotAuthenticateWhenJwtIsMissing() throws ServletException, IOException {
+       
+        when(jwtUtils.getJwtFromHeader(request)).thenReturn(null);
 
+        jwtAuthenticationFilter.doFilterInternal(request, response, filterChain);
+
+        verify(jwtUtils, never()).validateJwtToken(any());
+        verify(userDetailsService, never()).loadUserByUsername(any());
+        verify(filterChain).doFilter(request, response);
+        assert(SecurityContextHolder.getContext().getAuthentication() == null);
+    }
+
+    
+    
 }

--- a/src/test/java/com/f5/buzon_inteligente_BE/security/JwtAuthenticationFilterTest.java
+++ b/src/test/java/com/f5/buzon_inteligente_BE/security/JwtAuthenticationFilterTest.java
@@ -1,0 +1,48 @@
+package com.f5.buzon_inteligente_BE.security;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.core.userdetails.UserDetailsService;
+
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+
+
+@DisplayName("JwtAuthenticationFilterTest")
+public class JwtAuthenticationFilterTest {
+    @Mock
+    private JwtUtils jwtUtils;
+
+    @Mock
+    private UserDetailsService userDetailsService;
+
+    @Mock
+    private HttpServletRequest request;
+
+    @Mock
+    private HttpServletResponse response;
+
+    @Mock
+    private FilterChain filterChain;
+
+    @Mock
+    private UserDetails userdetails;
+
+    @InjectMocks
+    private JwtAuthenticationFilter jwtAuthenticationFilter;
+
+    @BeforeEach
+    void setUp() {
+        MockitoAnnotations.openMocks(this);
+        SecurityContextHolder.clearContext();        
+    }
+
+    
+
+}

--- a/src/test/java/com/f5/buzon_inteligente_BE/security/JwtAuthenticationFilterTest.java
+++ b/src/test/java/com/f5/buzon_inteligente_BE/security/JwtAuthenticationFilterTest.java
@@ -93,6 +93,24 @@ public class JwtAuthenticationFilterTest {
         assert(authentication.getAuthorities().isEmpty());
     }
 
+    @Test
+    @DisplayName("Should not authenticate user when JWT is invalid")
+    void shouldNotAuthenticateWhenJwtIsInvalid() throws ServletException, IOException {
+        String token = "invalid-jwt";
+
+        when(jwtUtils.getJwtFromHeader(request)).thenReturn(token);
+        when(jwtUtils.validateJwtToken(token)).thenReturn(false);
+
+        jwtAuthenticationFilter.doFilterInternal(request, response, filterChain);
+
+        verify(jwtUtils).getJwtFromHeader(request);
+        verify(jwtUtils).validateJwtToken(token);
+        verify(userDetailsService, never()).loadUserByUsername(any());
+        verify(filterChain).doFilter(request, response);
+
+        assert(SecurityContextHolder.getContext().getAuthentication() == null);
+    }
+
     
     
 }


### PR DESCRIPTION

- ✅ Implemented unit tests for `JwtAuthenticationFilter` with complete branch and line coverage.
- 🔄 Centralized common test data (`token`, `username`) into class-level variables and initialized in `@BeforeEach`.
- 🧩 Covered all critical scenarios:
  - ✅ Missing JWT token (no authentication performed)
  - ✅ Valid JWT token (successful authentication, context updated)
  - ✅ Invalid JWT token (no authentication performed)
  - ✅ Exception handling during token validation (filter chain proceeds without interruption)


[Test unitarios para JWJwtAuthenticationFilter](https://mabelrincon.atlassian.net/browse/TEST-4)

---

**Ready for merge! 🚀**


