### PR TITLE
TEST-13 Unit tests for the SecurityConfig class

### DIFF
--- a/src/test/java/com/f5/buzon_inteligente_BE/config/SecurityConfigTest.java
+++ b/src/test/java/com/f5/buzon_inteligente_BE/config/SecurityConfigTest.java
@@ -1,0 +1,77 @@
+package com.f5.buzon_inteligente_BE.config;
+
+import com.f5.buzon_inteligente_BE.security.CustomUserDetailsService;
+import com.f5.buzon_inteligente_BE.security.JwtUtils;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.springframework.security.authentication.AuthenticationManager;
+import org.springframework.security.config.annotation.authentication.builders.AuthenticationManagerBuilder;
+import org.springframework.security.config.annotation.authentication.configurers.userdetails.DaoAuthenticationConfigurer;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.security.web.SecurityFilterChain;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.*;
+
+@DisplayName("Unit tests for SecurityConfig")
+class SecurityConfigTest {
+
+    @Mock
+    private CustomUserDetailsService customUserDetailsService;
+
+    @Mock
+    private JwtUtils jwtUtils;
+
+    private SecurityConfig securityConfig;
+
+    @BeforeEach
+    void setUp() {
+        MockitoAnnotations.openMocks(this);
+        securityConfig = new SecurityConfig(customUserDetailsService, jwtUtils);
+    }
+
+    @Test
+    @DisplayName("Should return an instance of BCryptPasswordEncoder")
+    void testPasswordEncoderShouldReturnBCryptPasswordEncoder() {
+        PasswordEncoder encoder = securityConfig.passwordEncoder();
+        assertThat(encoder).isInstanceOf(org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder.class);
+    }
+
+    @Test
+    @DisplayName("Should successfully build SecurityFilterChain")
+    void testSecurityFilterChainShouldBuildSuccessfully() throws Exception {
+        HttpSecurity http = mock(HttpSecurity.class, RETURNS_DEEP_STUBS);
+
+        SecurityFilterChain filterChain = securityConfig.securityFilterChain(http);
+        assertThat(filterChain).isNotNull();
+    }
+
+    @Test
+    @DisplayName("Should successfully build AuthenticationManager with custom UserDetailsService and PasswordEncoder")
+    void testAuthenticationManagerShouldBuildSuccessfully() throws Exception {
+        HttpSecurity http = mock(HttpSecurity.class, RETURNS_DEEP_STUBS);
+        AuthenticationManagerBuilder builder = mock(AuthenticationManagerBuilder.class);
+        @SuppressWarnings("unchecked")
+        DaoAuthenticationConfigurer<AuthenticationManagerBuilder, CustomUserDetailsService> daoConfigurer = mock(
+                DaoAuthenticationConfigurer.class);
+
+        when(http.getSharedObject(AuthenticationManagerBuilder.class)).thenReturn(builder);
+        when(builder.userDetailsService(customUserDetailsService)).thenReturn(daoConfigurer);
+        when(daoConfigurer.passwordEncoder(any(PasswordEncoder.class))).thenReturn(daoConfigurer);
+        when(builder.build()).thenReturn(mock(AuthenticationManager.class));
+
+        AuthenticationManager authenticationManager = securityConfig.authenticationManager(http,
+                securityConfig.passwordEncoder());
+
+        assertThat(authenticationManager).isNotNull();
+
+        verify(builder).userDetailsService(customUserDetailsService);
+        verify(daoConfigurer).passwordEncoder(any(PasswordEncoder.class));
+    }
+
+}


### PR DESCRIPTION
### Esta PR añade tests unitarios para la clase `SecurityConfig` con el objetivo de asegurar que la configuración de seguridad esté correctamente definida.

### Cambios realizados

- Se añadieron tests para el bean `PasswordEncoder` (BCryptPasswordEncoder).
- Se añadieron tests para la configuración de `SecurityFilterChain`.
- Se añadieron tests para la configuración de `AuthenticationManager` con `CustomUserDetailsService` y `PasswordEncoder`.
- Cobertura de tests unitaria para toda la clase `SecurityConfig`.



[Unit tests for the SecurityConfig class](https://mabelrincon.atlassian.net/browse/TEST-13)

---

**¡Se agradece cualquier feedback! Estoy encantado/a de hacer ajustes si consideran que hay aspectos que se pueden mejorar 😊**

