### PR TITLE
feat: add MailboxStatus entity with JPA annotations

### DIFF
--- a/src/main/java/com/f5/buzon_inteligente_BE/mailbox/MailboxStatus.java
+++ b/src/main/java/com/f5/buzon_inteligente_BE/mailbox/MailboxStatus.java
@@ -25,8 +25,7 @@ public class MailboxStatus {
         return mailboxStatusName;
     }
 
-    public MailboxStatus(Long mailboxStatusId, String mailboxStatusName) {
-        this.mailboxStatusId = mailboxStatusId;
+    public MailboxStatus(String mailboxStatusName) {
         this.mailboxStatusName = mailboxStatusName;
     }
 

--- a/src/main/java/com/f5/buzon_inteligente_BE/mailbox/MailboxStatus.java
+++ b/src/main/java/com/f5/buzon_inteligente_BE/mailbox/MailboxStatus.java
@@ -29,4 +29,8 @@ public class MailboxStatus {
         this.mailboxStatusId = mailboxStatusId;
         this.mailboxStatusName = mailboxStatusName;
     }
+
+    public void setMailboxStatusName(String mailboxStatusName) {
+        this.mailboxStatusName = mailboxStatusName;
+    }
 }

--- a/src/main/java/com/f5/buzon_inteligente_BE/mailbox/MailboxStatus.java
+++ b/src/main/java/com/f5/buzon_inteligente_BE/mailbox/MailboxStatus.java
@@ -1,0 +1,32 @@
+package com.f5.buzon_inteligente_BE.mailbox;
+
+import jakarta.persistence.*;
+
+@Entity
+@Table(name = "mailbox_status")
+public class MailboxStatus {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "mailbox_status_id", nullable = false)
+    private Long mailboxStatusId;
+
+    @Column(name = "mailbox_status_name", nullable = false, length = 50)
+    private String mailboxStatusName;
+
+    public MailboxStatus() {
+    }
+
+    public Long getMailboxStatusId() {
+        return mailboxStatusId;
+    }
+
+    public String getMailboxStatusName() {
+        return mailboxStatusName;
+    }
+
+    public MailboxStatus(Long mailboxStatusId, String mailboxStatusName) {
+        this.mailboxStatusId = mailboxStatusId;
+        this.mailboxStatusName = mailboxStatusName;
+    }
+}


### PR DESCRIPTION
Este pull request introduce la entidad MailboxStatus, que representa los estados posibles de un buzón dentro del sistema Buzón Inteligente Backend (BE) . La clase está diseñada siguiendo las mejores prácticas de JPA (Java Persistence API) para mapear una tabla en la base de datos y proporcionar una estructura clara y escalable para gestionar los estados de los buzones.

Detalles de la implementación:
Mapeo de la entidad:
La clase está anotada con Entity, lo que indica que es una entidad persistente en el contexto de JPA.
Se define la tabla correspondiente en la base de datos mediante la anotación Table(name = "mailbox_status").
Campos principales:
mailboxStatusId: Es la clave primaria de la entidad, generada automáticamente mediante la estrategia GenerationType.IDENTITY. Este campo no puede ser nulo (nullable = false) y está mapeado a la columna mailbox_status_id.
mailboxStatusName: Representa el nombre del estado del buzón. Este campo tiene una longitud máxima de 50 caracteres (length = 50) y tampoco puede ser nulo (nullable = false). Está mapeado a la columna mailbox_status_name.
Constructores:
Se incluye un constructor vacío requerido por JPA para la creación de instancias mediante reflexión.
Un constructor sobrecargado permite inicializar los campos mailboxStatusId y mailboxStatusName directamente.
Métodos getter:
Se proporcionan métodos getMailboxStatusId() y getMailboxStatusName() para acceder a los valores de los campos privados.