### PR TITLE
Buz 167 dto respuesta user profile

### DIFF
--- a/src/main/java/com/f5/buzon_inteligente_BE/locker/Locker.java
+++ b/src/main/java/com/f5/buzon_inteligente_BE/locker/Locker.java
@@ -1,4 +1,4 @@
-package com.f5.buzon_inteligente_BE.locker;
+/*package com.f5.buzon_inteligente_BE.locker;
 
 import java.io.Serializable;
 import java.util.ArrayList;
@@ -81,3 +81,5 @@ public class Locker implements Serializable {
         return users;
     }
 }
+
+*/

--- a/src/main/java/com/f5/buzon_inteligente_BE/locker/Locker.java
+++ b/src/main/java/com/f5/buzon_inteligente_BE/locker/Locker.java
@@ -1,4 +1,4 @@
-/*package com.f5.buzon_inteligente_BE.locker;
+package com.f5.buzon_inteligente_BE.locker;
 
 import java.io.Serializable;
 import java.util.ArrayList;
@@ -82,4 +82,3 @@ public class Locker implements Serializable {
     }
 }
 
-*/

--- a/src/main/java/com/f5/buzon_inteligente_BE/profile/DTO/ProfileDTO.java
+++ b/src/main/java/com/f5/buzon_inteligente_BE/profile/DTO/ProfileDTO.java
@@ -1,4 +1,7 @@
-package com.f5.buzon_inteligente_BE.profile;
+package com.f5.buzon_inteligente_BE.profile.DTO;
+
+import com.f5.buzon_inteligente_BE.profile.Profile;
+
 
 public class ProfileDTO {
     

--- a/src/main/java/com/f5/buzon_inteligente_BE/profile/DTO/UserProfileResponseDTO.java
+++ b/src/main/java/com/f5/buzon_inteligente_BE/profile/DTO/UserProfileResponseDTO.java
@@ -1,0 +1,74 @@
+package com.f5.buzon_inteligente_BE.profile.DTO;
+
+import com.f5.buzon_inteligente_BE.profile.Profile;
+import com.f5.buzon_inteligente_BE.user.User;
+
+public class UserProfileResponseDTO {
+
+    private String userDni;
+    private String userName;
+    private String userSurname;
+    private String userEmail;
+
+    private String permanentCredential;
+
+    public UserProfileResponseDTO() {
+    }
+
+    public UserProfileResponseDTO(String userDni, String userName, String userSurname, String userEmail,
+            String permanentCredential) {
+        this.userDni = userDni;
+        this.userName = userName;
+        this.userSurname = userSurname;
+        this.userEmail = userEmail;
+        this.permanentCredential = permanentCredential;
+    }
+
+    public static UserProfileResponseDTO fromEntities(User user, Profile profile) {
+        return new UserProfileResponseDTO(
+                user.getUserDni(),
+                user.getUserName(),
+                user.getUserSurname(),
+                user.getUserEmail(),
+                profile.getPermanentCredential()
+
+        );
+    }
+
+    public String getUserDni() {
+        return userDni;
+    }
+
+    public void setUserDni(String userDni) {
+        this.userDni = userDni;
+    }
+
+    public String getUserName() {
+        return userName;
+    }
+
+    public void setUserName(String userName) {
+        this.userName = userName;
+    }
+
+    public String getUserSurname() {
+        return userSurname;
+    }
+
+    public void setUserSurname(String userSurname) {
+        this.userSurname = userSurname;
+    }
+
+    public String getUserEmail() {
+        return userEmail;
+    }
+
+    public void setUserEmail(String userEmail) {
+        this.userEmail = userEmail;
+    }
+
+    public String getPermanentCredential() {
+        return permanentCredential;
+    }
+
+}

--- a/src/main/java/com/f5/buzon_inteligente_BE/profile/ProfileController.java
+++ b/src/main/java/com/f5/buzon_inteligente_BE/profile/ProfileController.java
@@ -1,9 +1,11 @@
 package com.f5.buzon_inteligente_BE.profile;
 
-
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
+
+import com.f5.buzon_inteligente_BE.profile.DTO.ProfileDTO;
+import com.f5.buzon_inteligente_BE.profile.DTO.UserProfileResponseDTO;
 
 import java.util.List;
 import java.util.stream.Collectors;
@@ -36,27 +38,25 @@ public class ProfileController {
     }
 
     @GetMapping("/user/{userId}")
-    public ResponseEntity<ProfileDTO> getProfileByUserId(@PathVariable Long userId) {
+    public ResponseEntity<UserProfileResponseDTO> getProfileByUserId(@PathVariable Long userId) {
         return profileService.getProfileByUserId(userId)
-                .map(ProfileDTO::fromEntity)
+                .map(profile -> UserProfileResponseDTO.fromEntities(profile.getUser(), profile))
                 .map(ResponseEntity::ok)
                 .orElse(ResponseEntity.notFound().build());
     }
 
-   
     @PostMapping
-    public ResponseEntity<ProfileDTO> createProfile(@RequestBody CreateProfileRequest request) {
+    public ResponseEntity<UserProfileResponseDTO> createProfile(@RequestBody CreateProfileRequest request) {
         Profile createdProfile = profileService.createProfile(request.getUserId());
-        return new ResponseEntity<>(ProfileDTO.fromEntity(createdProfile), HttpStatus.CREATED);
+        return new ResponseEntity<>(UserProfileResponseDTO.fromEntities(createdProfile.getUser(), createdProfile),
+                HttpStatus.CREATED);
     }
 
-   
     @PutMapping("/{id}")
     public ResponseEntity<ProfileDTO> updateProfile(@PathVariable Long id, @RequestBody UpdateProfileRequest request) {
         Profile updatedProfile = profileService.updateProfile(id, request.getPermanentCredential());
         return ResponseEntity.ok(ProfileDTO.fromEntity(updatedProfile));
     }
-
 
     @PostMapping("/{id}/regenerate-credential")
     public ResponseEntity<String> regenerateCredential(@PathVariable Long id) {
@@ -70,7 +70,6 @@ public class ProfileController {
         return ResponseEntity.noContent().build();
     }
 
-
     public static class CreateProfileRequest {
         private Long userId;
 
@@ -82,7 +81,6 @@ public class ProfileController {
             this.userId = userId;
         }
     }
-
 
     public static class UpdateProfileRequest {
         private String permanentCredential;


### PR DESCRIPTION
[Jira](https://grigorivladimiro.atlassian.net/browse/BUZ-167)

En esta PR se realizaron los siguientes cambios para mejorar la integración del perfil del usuario:

- [ ] Creación de la carpeta DTO en el paquete Profile:

Se creó el paquete com.f5.buzon_inteligente_BE.profile.DTO (o siguiendo la convención de minúsculas: com.f5.buzon_inteligente_BE.profile.dto) para agrupar los DTOs relacionados con la funcionalidad de perfiles.

- [ ] Implementación de UserProfileResponseDTO:

Se desarrolló el DTO consolidado UserProfileResponseDTO que combina información esencial de la entidad User (como userDni, userName, userSurname y userEmail) y la permanentCredential generada en la entidad Profile.

Este DTO permite al front-end obtener de forma unificada todos los datos del perfil del usuario (sin exponer el userId), facilitando así la visualización y posterior actualización de la información.

- [ ] 
![chrome-capture-2025-4-16](https://github.com/user-attachments/assets/1b05a3c2-09a6-45ec-95eb-ae6cc4066627)
Actualización del ProfileController:

Se ajustaron los endpoints del controlador para que, en la ruta /api/profile/user/{userId}, se devuelva la respuesta utilizando el nuevo DTO consolidado (UserProfileResponseDTO), en lugar del DTO anterior.

Esto garantiza que al hacer la petición (por ejemplo, /api/profile/user/7) se obtenga todo el perfil del cliente de forma estructurada