### PR TITLE
Buz 162 crear entidad mailbox sizes

### DIFF
--- a/src/main/java/com/f5/buzon_inteligente_BE/mailbox/MailboxSize.java
+++ b/src/main/java/com/f5/buzon_inteligente_BE/mailbox/MailboxSize.java
@@ -16,13 +16,13 @@ public class MailboxSize {
     private Long mailboxSizeId;
 
     @Column(name = "size_name", nullable = false, length = 50)
-    private String mailboxStatusName;
+    private String mailboxSizeName;
 
     public MailboxSize() {
     }
 
-    public MailboxSize(String mailboxStatusName) {
-        this.mailboxStatusName = mailboxStatusName;
+    public MailboxSize(String mailboxSizeName) {
+        this.mailboxSizeName = mailboxSizeName;
     }
 
     public Long getMailboxSizeId() {
@@ -30,11 +30,11 @@ public class MailboxSize {
     }
 
     public String getMailboxStatusName() {
-        return mailboxStatusName;
+        return mailboxSizeName;
     }
 
-    public void setMailboxStatusName(String mailboxStatusName) {
-        this.mailboxStatusName = mailboxStatusName;
+    public void setMailboxStatusName(String mailboxSizeName) {
+        this.mailboxSizeName = mailboxSizeName;
     }
 
 }

--- a/src/main/java/com/f5/buzon_inteligente_BE/mailbox/MailboxSize.java
+++ b/src/main/java/com/f5/buzon_inteligente_BE/mailbox/MailboxSize.java
@@ -10,36 +10,31 @@ import jakarta.persistence.Table;
 @Entity
 @Table(name = "mailbox_sizes")
 public class MailboxSize {
-    @Id 
+    @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
-    @Column(name = "mailbox_size_id",nullable = false)    
+    @Column(name = "mailbox_size_id", nullable = false)
     private Long mailboxSizeId;
 
-@Column(name = "size_name",nullable =  false,length = 50) 
+    @Column(name = "size_name", nullable = false, length = 50)
     private String mailboxStatusName;
 
-public MailboxSize() {
-}
+    public MailboxSize() {
+    }
 
+    public MailboxSize(String mailboxStatusName) {
+        this.mailboxStatusName = mailboxStatusName;
+    }
 
-public MailboxSize(Long mailboxSizeId, String mailboxStatusName) {
-    this.mailboxSizeId = mailboxSizeId;
-    this.mailboxStatusName = mailboxStatusName;
-}
+    public Long getMailboxSizeId() {
+        return mailboxSizeId;
+    }
 
+    public String getMailboxStatusName() {
+        return mailboxStatusName;
+    }
 
-public Long getMailboxSizeId() {
-    return mailboxSizeId;
-}
-
-
-public String getMailboxStatusName() {
-    return mailboxStatusName;
-}
-
-public void setMailboxStatusName(String mailboxStatusName) {
-    this.mailboxStatusName = mailboxStatusName;
-}
-
+    public void setMailboxStatusName(String mailboxStatusName) {
+        this.mailboxStatusName = mailboxStatusName;
+    }
 
 }

--- a/src/main/java/com/f5/buzon_inteligente_BE/mailbox/MailboxSize.java
+++ b/src/main/java/com/f5/buzon_inteligente_BE/mailbox/MailboxSize.java
@@ -1,0 +1,45 @@
+package com.f5.buzon_inteligente_BE.mailbox;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+
+@Entity
+@Table(name = "mailbox_sizes")
+public class MailboxSize {
+    @Id 
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "mailbox_size_id",nullable = false)    
+    private Long mailboxSizeId;
+
+@Column(name = "size_name",nullable =  false,length = 50) 
+    private String mailboxStatusName;
+
+public MailboxSize() {
+}
+
+
+public MailboxSize(Long mailboxSizeId, String mailboxStatusName) {
+    this.mailboxSizeId = mailboxSizeId;
+    this.mailboxStatusName = mailboxStatusName;
+}
+
+
+public Long getMailboxSizeId() {
+    return mailboxSizeId;
+}
+
+
+public String getMailboxStatusName() {
+    return mailboxStatusName;
+}
+
+public void setMailboxStatusName(String mailboxStatusName) {
+    this.mailboxStatusName = mailboxStatusName;
+}
+
+
+}

--- a/src/main/java/com/f5/buzon_inteligente_BE/mailbox/MailboxSize.java
+++ b/src/main/java/com/f5/buzon_inteligente_BE/mailbox/MailboxSize.java
@@ -29,11 +29,11 @@ public class MailboxSize {
         return mailboxSizeId;
     }
 
-    public String getMailboxStatusName() {
+    public String getMailboxSizeName() {
         return mailboxSizeName;
     }
 
-    public void setMailboxStatusName(String mailboxSizeName) {
+    public void setMailboxSizeName(String mailboxSizeName) {
         this.mailboxSizeName = mailboxSizeName;
     }
 


### PR DESCRIPTION
## ✉️ MailboxSize Entity

Se añade la clase `MailboxSize` dentro del paquete `com.f5.buzon_inteligente_BE.mailbox`, que representa los distintos tamaños o estados de un buzón inteligente.

### 📌 Características principales:
- Mapeada como entidad JPA (`@Entity`) y vinculada a la tabla `mailbox_sizes`.
- Contiene los siguientes campos:
  - `mailboxSizeId`: Identificador único autogenerado.
  - `mailboxStatusName`: Nombre o descripción del tamaño/estado del buzón, limitado a 50 caracteres.
- Incluye constructor vacío y constructor con parámetros.
- Métodos `getter` y `setter` para los atributos.

### ✅ Objetivo:
Este modelo permitirá gestionar y clasificar los diferentes tamaños o estados de los buzones, facilitando la persistencia en base de datos y su posterior uso dentro del sistema.

---

🔧 Esta implementación forma parte del desarrollo backend del sistema **Buzón Inteligente**.


