### PR TITLE
feat: Add AccessCodeStatus entity with relationships

### DIFF
--- a/src/main/java/com/f5/buzon_inteligente_BE/accesscode/AccessCodeStatus.java
+++ b/src/main/java/com/f5/buzon_inteligente_BE/accesscode/AccessCodeStatus.java
@@ -3,14 +3,13 @@ package com.f5.buzon_inteligente_BE.accesscode;
 import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.List;
-
-import com.f5.buzon_inteligente_BE.accesscode.AccessCode;
-
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import jakarta.persistence.*;
 
 @Entity
 @Table(name = "access_code_status")
 public class AccessCodeStatus implements Serializable {
+    private static final long serialVersionUID = 1L;
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -20,7 +19,9 @@ public class AccessCodeStatus implements Serializable {
     @Column(name = "access_code_status_name", nullable = false, length = 50)
     private String accessCodeStatusName;
 
-    @OneToMany(mappedBy = "accessCodeStatus", cascade = CascadeType.ALL)
+    @OneToMany(mappedBy = "accessCodeStatus", cascade = { CascadeType.PERSIST,
+            CascadeType.MERGE }, orphanRemoval = true)
+    @JsonIgnore
     private List<AccessCode> accessCodes = new ArrayList<>();
 
     public AccessCodeStatus() {

--- a/src/main/java/com/f5/buzon_inteligente_BE/accesscode/AccessCodeStatus.java
+++ b/src/main/java/com/f5/buzon_inteligente_BE/accesscode/AccessCodeStatus.java
@@ -1,0 +1,48 @@
+package com.f5.buzon_inteligente_BE.accesscode;
+
+import java.io.Serializable;
+import java.util.ArrayList;
+import java.util.List;
+
+import com.f5.buzon_inteligente_BE.accesscode.AccessCode;
+
+import jakarta.persistence.*;
+
+@Entity
+@Table(name = "access_code_status")
+public class AccessCodeStatus implements Serializable {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "access_code_status_id", nullable = false)
+    private Long accessCodeStatusId;
+
+    @Column(name = "access_code_status_name", nullable = false, length = 50)
+    private String accessCodeStatusName;
+
+    @OneToMany(mappedBy = "accessCodeStatus", cascade = CascadeType.ALL)
+    private List<AccessCode> accessCodes = new ArrayList<>();
+
+    public AccessCodeStatus() {
+    }
+
+    public AccessCodeStatus(String accessCodeStatusName) {
+        this.accessCodeStatusName = accessCodeStatusName;
+    }
+
+    public Long getAccessCodeStatusId() {
+        return accessCodeStatusId;
+    }
+
+    public String getAccessCodeStatusName() {
+        return accessCodeStatusName;
+    }
+
+    public void setAccessCodeStatusName(String accessCodeStatusName) {
+        this.accessCodeStatusName = accessCodeStatusName;
+    }
+
+    public List<AccessCode> getAccessCodes() {
+        return accessCodes;
+    }
+}


### PR DESCRIPTION
* Se creó la entidad AccessCodeStatus como una nueva clase persistente para representar el estado de un código de acceso.

* Se definieron los campos accessCodeStatusId (ID autogenerado) y accessCodeStatusName (nombre del estado).

* Se estableció una relación OneToMany con la entidad AccessCode, permitiendo que un estado esté asociado a múltiples códigos de acceso.

* Se implementaron constructores, getters y setters necesarios para el manejo de la entidad.