### PR TITLE
TEST-49 RegisterExceptions tested

### DIFF
--- a/src/test/java/com/f5/buzon_inteligente_BE/auth/register/RegisterExceptionsTest.java
+++ b/src/test/java/com/f5/buzon_inteligente_BE/auth/register/RegisterExceptionsTest.java
@@ -1,0 +1,46 @@
+package com.f5.buzon_inteligente_BE.auth.register;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import com.f5.buzon_inteligente_BE.auth.register.RegisterExceptions.DniAlreadyExistsException;
+import com.f5.buzon_inteligente_BE.auth.register.RegisterExceptions.EmailAlreadyExistsException;
+import com.f5.buzon_inteligente_BE.auth.register.RegisterExceptions.RegisterException;
+
+public class RegisterExceptionsTest {
+    @Test
+    @DisplayName("RegisterException test case")
+    void testException() {
+        RegisterExceptions registerExceptions = new RegisterExceptions();
+        assertNotNull(registerExceptions);        
+    }
+    @Test
+    @DisplayName("RegisterException email already exists test case")
+    void testEmailAlreadyExistsException() {
+        EmailAlreadyExistsException registerException = new EmailAlreadyExistsException("message");
+        assertEquals("message", registerException.getMessage());
+    }
+    @Test
+    @DisplayName("RegisterException dni already exists test case")
+    void testDniAlreadyExistsException() {
+        DniAlreadyExistsException registerException = new DniAlreadyExistsException("message");
+        assertEquals("message", registerException.getMessage());
+    }
+    @Test
+    @DisplayName("RegisterException test case")
+    void testRegisterException() {
+        RegisterException registerException = new RegisterException("message");
+        assertEquals("message", registerException.getMessage());
+    }
+    @Test
+    @DisplayName("RegisterException with cause test case")
+    void testRegisterExceptionWithCause() {
+        Throwable cause = new RuntimeException("Causa original");
+        RegisterException registerException = new RegisterException("message", cause);
+        assertEquals("message", registerException.getMessage());
+        assertEquals(cause, registerException.getCause());
+    }
+}


### PR DESCRIPTION
## ✅ Añadir tests unitarios para excepciones personalizadas de registro

### 📌 Descripción

Se añaden pruebas unitarias para la clase `RegisterExceptions` y sus clases internas:

- `EmailAlreadyExistsException`
- `DniAlreadyExistsException`
- `RegisterException` (con y sin causa)

Estas pruebas cubren la correcta inicialización de las excepciones, verificando que los mensajes y las causas se almacenan correctamente.

---

### 🔍 Cambios realizados

- Se crea la clase `RegisterExceptionsTest` para testear:
  - La instanciación de `RegisterExceptions` como clase contenedora.
  - El comportamiento del constructor de cada excepción anidada.
  - El constructor de `RegisterException` que acepta una causa (`Throwable`).
---

### 🧠 Notas

> Aunque `RegisterExceptions` no está pensada para ser instanciada, se ha incluido una prueba básica de instanciación para completar la cobertura de la clase según las herramientas de análisis estático.
