### PR TITLE
TEST-54 Tests unitarios para `ProfileDTO` con cobertura de casos límite

### DIFF
--- a/src/test/java/com/f5/buzon_inteligente_BE/profile/dto/ProfileDTOTest.java
+++ b/src/test/java/com/f5/buzon_inteligente_BE/profile/dto/ProfileDTOTest.java
@@ -64,5 +64,19 @@ public class ProfileDTOTest {
         assertEquals("CRED001", dto.getPermanentCredential());
         assertEquals(100L, dto.getUserId());
     }
+
+    @Test
+    @DisplayName("Should convert Profile to ProfileDTO when user is null")
+    void testShouldFromEntityWithoutUser() {
+        profile.setId(6L);
+        profile.setPermanentCredential("CRED002");
+        profile.setUser(null);
+
+        ProfileDTO dto = ProfileDTO.fromEntity(profile);
+
+        assertEquals(6L, dto.getId());
+        assertEquals("CRED002", dto.getPermanentCredential());
+        assertNull(dto.getUserId());
+    }
     
 }

--- a/src/test/java/com/f5/buzon_inteligente_BE/profile/dto/ProfileDTOTest.java
+++ b/src/test/java/com/f5/buzon_inteligente_BE/profile/dto/ProfileDTOTest.java
@@ -85,5 +85,17 @@ public class ProfileDTOTest {
             ProfileDTO.fromEntity(null);
         });
     }
+
+    @Test
+    @DisplayName("Should handle empty permanentCredential")
+    void testShouldWithEmptyPermanentCredential() {
+        profile.setId(7L);
+        profile.setPermanentCredential("");
+        profile.setUser(null);
+
+        ProfileDTO dto = ProfileDTO.fromEntity(profile);
+
+        assertEquals("", dto.getPermanentCredential());
+    }
     
 }

--- a/src/test/java/com/f5/buzon_inteligente_BE/profile/dto/ProfileDTOTest.java
+++ b/src/test/java/com/f5/buzon_inteligente_BE/profile/dto/ProfileDTOTest.java
@@ -1,0 +1,54 @@
+package com.f5.buzon_inteligente_BE.profile.dto;
+
+import com.f5.buzon_inteligente_BE.profile.Profile;
+import com.f5.buzon_inteligente_BE.profile.DTO.ProfileDTO;
+import com.f5.buzon_inteligente_BE.user.User;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+public class ProfileDTOTest {
+
+    private Profile profile;
+    private User mockUser;
+
+    @BeforeEach
+    void setUp() {
+        profile = new Profile();
+        profile.setId(1L);
+        profile.setPermanentCredential("DEFAULT_CREDENTIAL");
+
+        mockUser = new User() {
+            @Override
+            public Long getUserId() {
+                return 100L;
+            }
+        };
+    }
+
+    @Test
+    @DisplayName("Should create empty ProfileDTO and set values with setters")
+    void testShouldNoArgsConstructorAndSetters() {
+        ProfileDTO dto = new ProfileDTO();
+        dto.setId(1L);
+        dto.setPermanentCredential("ABC123");
+        dto.setUserId(10L);
+
+        assertEquals(1L, dto.getId());
+        assertEquals("ABC123", dto.getPermanentCredential());
+        assertEquals(10L, dto.getUserId());
+    }
+
+    @Test
+    @DisplayName("Should create ProfileDTO using all-args constructor")
+    void testShouldAllArgsConstructor() {
+        ProfileDTO dto = new ProfileDTO(2L, "XYZ456", 20L);
+
+        assertEquals(2L, dto.getId());
+        assertEquals("XYZ456", dto.getPermanentCredential());
+        assertEquals(20L, dto.getUserId());
+    }
+    
+}

--- a/src/test/java/com/f5/buzon_inteligente_BE/profile/dto/ProfileDTOTest.java
+++ b/src/test/java/com/f5/buzon_inteligente_BE/profile/dto/ProfileDTOTest.java
@@ -79,7 +79,7 @@ public class ProfileDTOTest {
         assertNull(dto.getUserId());
     }
     @Test
-    @DisplayName("Should handle null Profile in fromEntity gracefully (edge case)")
+    @DisplayName("Should handle null Profile in from Entity gracefully (edge case)")
     void testShouldFromEntityWithNullProfile() {
         assertThrows(NullPointerException.class, () -> {
             ProfileDTO.fromEntity(null);
@@ -87,7 +87,7 @@ public class ProfileDTOTest {
     }
 
     @Test
-    @DisplayName("Should handle empty permanentCredential")
+    @DisplayName("Should handle empty permanent Credential")
     void testShouldWithEmptyPermanentCredential() {
         profile.setId(7L);
         profile.setPermanentCredential("");

--- a/src/test/java/com/f5/buzon_inteligente_BE/profile/dto/ProfileDTOTest.java
+++ b/src/test/java/com/f5/buzon_inteligente_BE/profile/dto/ProfileDTOTest.java
@@ -78,5 +78,12 @@ public class ProfileDTOTest {
         assertEquals("CRED002", dto.getPermanentCredential());
         assertNull(dto.getUserId());
     }
+    @Test
+    @DisplayName("Should handle null Profile in fromEntity gracefully (edge case)")
+    void testShouldFromEntityWithNullProfile() {
+        assertThrows(NullPointerException.class, () -> {
+            ProfileDTO.fromEntity(null);
+        });
+    }
     
 }

--- a/src/test/java/com/f5/buzon_inteligente_BE/profile/dto/ProfileDTOTest.java
+++ b/src/test/java/com/f5/buzon_inteligente_BE/profile/dto/ProfileDTOTest.java
@@ -50,5 +50,19 @@ public class ProfileDTOTest {
         assertEquals("XYZ456", dto.getPermanentCredential());
         assertEquals(20L, dto.getUserId());
     }
+
+    @Test
+    @DisplayName("Should convert Profile to ProfileDTO when user is not null")
+    void testShouldFromEntityWithUser() {
+        profile.setId(5L);
+        profile.setPermanentCredential("CRED001");
+        profile.setUser(mockUser);
+
+        ProfileDTO dto = ProfileDTO.fromEntity(profile);
+
+        assertEquals(5L, dto.getId());
+        assertEquals("CRED001", dto.getPermanentCredential());
+        assertEquals(100L, dto.getUserId());
+    }
     
 }


### PR DESCRIPTION
### 📝 Descripción

Esta Pull Request incorpora una serie de pruebas unitarias que validan el correcto funcionamiento de la clase `ProfileDTO`, incluyendo sus constructores, métodos `getter/setter`, y el método estático `fromEntity(Profile)`.

También se han incluido pruebas para casos límite, garantizando una cobertura robusta ante posibles valores nulos o vacíos.

---

### 🔧 Cambios realizados

- ✅ Test del constructor sin argumentos y uso de setters.
- ✅ Test del constructor con todos los argumentos.
- ✅ Test del método `fromEntity()` cuando el `Profile` tiene un `User`.
- ✅ Test del método `fromEntity()` cuando el `Profile` no tiene un `User`.
- ✅ Test de `fromEntity()` con valor `null` como argumento.
- ✅ Test con campo `permanentCredential` vacío.
- ✅ Refactorización con `@BeforeEach` para reutilizar objetos comunes.

[Tests unitarios para `ProfileDTO` ](https://mabelrincon.atlassian.net/browse/TEST-54)

---
> **¡Se agradece cualquier feedback! Estoy encantada de hacer ajustes si consideran que hay aspectos que se pueden mejorar 😊**