### PR TITLE
TEST-55  Test de Integración de la clase ProfileRepository

### DIFF
--- a/src/test/java/com/f5/buzon_inteligente_BE/profile/ProfileRepositoryIntegrationTest.java
+++ b/src/test/java/com/f5/buzon_inteligente_BE/profile/ProfileRepositoryIntegrationTest.java
@@ -136,4 +136,11 @@ class ProfileRepositoryIntegrationTest {
         assertThat(result).isEmpty();
     }
 
+    @Test
+    @DisplayName("Should return false when credential is empty")
+    void testShouldExistsByPermanentCredential_shouldReturnFalse_whenCredentialIsEmpty() {
+        boolean exists = profileRepository.existsByPermanentCredential("");
+        assertThat(exists).isFalse();
+    }
+
 }

--- a/src/test/java/com/f5/buzon_inteligente_BE/profile/ProfileRepositoryIntegrationTest.java
+++ b/src/test/java/com/f5/buzon_inteligente_BE/profile/ProfileRepositoryIntegrationTest.java
@@ -67,7 +67,7 @@ class ProfileRepositoryIntegrationTest {
 
     @Test
     @DisplayName("Should return profile when user ID exists")
-    void testShouldfindByUserUserId_shouldReturnProfile() {
+    void testShouldFindByUserUserId_shouldReturnProfile() {
         User user = createUserWithProfile("12345678A", "Pepe", "pepe@example.com", "abc123");
 
         Optional<Profile> result = profileRepository.findByUserUserId(user.getUserId());
@@ -78,7 +78,7 @@ class ProfileRepositoryIntegrationTest {
 
     @Test
     @DisplayName("Should return true when profile exists for user")
-    void testShouldexistsByUserUserId_shouldReturnTrue() {
+    void testShouldExistsByUserUserId_shouldReturnTrue() {
         User user = createUserWithProfile("98765432B", "Carlos", "carlos@example.com", "cred456");
 
         boolean exists = profileRepository.existsByUserUserId(user.getUserId());
@@ -88,7 +88,7 @@ class ProfileRepositoryIntegrationTest {
 
     @Test
     @DisplayName("Should return profile when credential exists")
-    void testShouldfindByPermanentCredential_shouldReturnProfile() {
+    void testShouldFindByPermanentCredential_shouldReturnProfile() {
         createUserWithProfile("24681357C", "Ana", "ana@example.com", "unique_cred");
 
         Optional<Profile> result = profileRepository.findByPermanentCredential("unique_cred");
@@ -99,12 +99,20 @@ class ProfileRepositoryIntegrationTest {
 
     @Test
     @DisplayName("Should return true when credential exists")
-    void testShouldexistsByPermanentCredential_shouldReturnTrue() {
+    void testShouldExistsByPermanentCredential_shouldReturnTrue() {
         createUserWithProfile("11223344D", "Laura", "laura@example.com", "exists_cred");
 
         boolean exists = profileRepository.existsByPermanentCredential("exists_cred");
 
         assertThat(exists).isTrue();
+    }
+
+    @Test
+    @DisplayName("Should return false when credential does not exist")
+    void testShouldExistsByPermanentCredential_shouldReturnFalse() {
+        boolean exists = profileRepository.existsByPermanentCredential("non_existing_cred");
+
+        assertThat(exists).isFalse();
     }
 
 }

--- a/src/test/java/com/f5/buzon_inteligente_BE/profile/ProfileRepositoryIntegrationTest.java
+++ b/src/test/java/com/f5/buzon_inteligente_BE/profile/ProfileRepositoryIntegrationTest.java
@@ -129,4 +129,11 @@ class ProfileRepositoryIntegrationTest {
         assertThat(result).isEmpty();
     }
 
+    @Test
+    @DisplayName("Should return empty when credential is null")
+    void testShouldFindByPermanentCredential_shouldReturnEmpty_whenCredentialIsNull() {
+        Optional<Profile> result = profileRepository.findByPermanentCredential(null);
+        assertThat(result).isEmpty();
+    }
+
 }

--- a/src/test/java/com/f5/buzon_inteligente_BE/profile/ProfileRepositoryIntegrationTest.java
+++ b/src/test/java/com/f5/buzon_inteligente_BE/profile/ProfileRepositoryIntegrationTest.java
@@ -115,4 +115,11 @@ class ProfileRepositoryIntegrationTest {
         assertThat(exists).isFalse();
     }
 
+    @Test
+    @DisplayName("Should return empty when userId is null")
+    void testShouldFindByUserUserId_shouldReturnEmpty_whenUserIdIsNull() {
+        Optional<Profile> result = profileRepository.findByUserUserId(null);
+        assertThat(result).isNotPresent();
+    }
+
 }

--- a/src/test/java/com/f5/buzon_inteligente_BE/profile/ProfileRepositoryIntegrationTest.java
+++ b/src/test/java/com/f5/buzon_inteligente_BE/profile/ProfileRepositoryIntegrationTest.java
@@ -122,4 +122,11 @@ class ProfileRepositoryIntegrationTest {
         assertThat(result).isNotPresent();
     }
 
+    @Test
+    @DisplayName("Should return empty when user does not exist")
+    void testShouldFindByUserUserId_shouldReturnEmpty_whenUserDoesNotExist() {
+        Optional<Profile> result = profileRepository.findByUserUserId(99999L);
+        assertThat(result).isEmpty();
+    }
+
 }

--- a/src/test/java/com/f5/buzon_inteligente_BE/profile/ProfileRepositoryIntegrationTest.java
+++ b/src/test/java/com/f5/buzon_inteligente_BE/profile/ProfileRepositoryIntegrationTest.java
@@ -9,7 +9,10 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
 import org.springframework.test.context.ActiveProfiles;
 
+import static org.assertj.core.api.Assertions.*;
+
 import java.lang.reflect.Field;
+import java.util.Optional;
 
 @DataJpaTest
 @ActiveProfiles("test")
@@ -60,6 +63,17 @@ class ProfileRepositoryIntegrationTest {
             throw new RuntimeException("Failed to set roleName via reflection", e);
         }
         return roleRepository.save(role);
+    }
+
+    @Test
+    @DisplayName("Should return profile when user ID exists")
+    void testShouldfindByUserUserId_shouldReturnProfile() {
+        User user = createUserWithProfile("12345678A", "Pepe", "pepe@example.com", "abc123");
+
+        Optional<Profile> result = profileRepository.findByUserUserId(user.getUserId());
+
+        assertThat(result).isPresent();
+        assertThat(result.get().getUser().getUserName()).isEqualTo("Pepe");
     }
 
 }

--- a/src/test/java/com/f5/buzon_inteligente_BE/profile/ProfileRepositoryIntegrationTest.java
+++ b/src/test/java/com/f5/buzon_inteligente_BE/profile/ProfileRepositoryIntegrationTest.java
@@ -143,4 +143,11 @@ class ProfileRepositoryIntegrationTest {
         assertThat(exists).isFalse();
     }
 
+    @Test
+    @DisplayName("Should return false when userId is negative")
+    void testShouldExistsByUserUserId_shouldReturnFalse_whenUserIdIsNegative() {
+        boolean exists = profileRepository.existsByUserUserId(-1L);
+        assertThat(exists).isFalse();
+    }
+
 }

--- a/src/test/java/com/f5/buzon_inteligente_BE/profile/ProfileRepositoryIntegrationTest.java
+++ b/src/test/java/com/f5/buzon_inteligente_BE/profile/ProfileRepositoryIntegrationTest.java
@@ -86,4 +86,15 @@ class ProfileRepositoryIntegrationTest {
         assertThat(exists).isTrue();
     }
 
+    @Test
+    @DisplayName("Should return profile when credential exists")
+    void testShouldfindByPermanentCredential_shouldReturnProfile() {
+        createUserWithProfile("24681357C", "Ana", "ana@example.com", "unique_cred");
+
+        Optional<Profile> result = profileRepository.findByPermanentCredential("unique_cred");
+
+        assertThat(result).isPresent();
+        assertThat(result.get().getUser().getUserName()).isEqualTo("Ana");
+    }
+
 }

--- a/src/test/java/com/f5/buzon_inteligente_BE/profile/ProfileRepositoryIntegrationTest.java
+++ b/src/test/java/com/f5/buzon_inteligente_BE/profile/ProfileRepositoryIntegrationTest.java
@@ -76,4 +76,14 @@ class ProfileRepositoryIntegrationTest {
         assertThat(result.get().getUser().getUserName()).isEqualTo("Pepe");
     }
 
+    @Test
+    @DisplayName("Should return true when profile exists for user")
+    void testShouldexistsByUserUserId_shouldReturnTrue() {
+        User user = createUserWithProfile("98765432B", "Carlos", "carlos@example.com", "cred456");
+
+        boolean exists = profileRepository.existsByUserUserId(user.getUserId());
+
+        assertThat(exists).isTrue();
+    }
+
 }

--- a/src/test/java/com/f5/buzon_inteligente_BE/profile/ProfileRepositoryIntegrationTest.java
+++ b/src/test/java/com/f5/buzon_inteligente_BE/profile/ProfileRepositoryIntegrationTest.java
@@ -97,4 +97,14 @@ class ProfileRepositoryIntegrationTest {
         assertThat(result.get().getUser().getUserName()).isEqualTo("Ana");
     }
 
+    @Test
+    @DisplayName("Should return true when credential exists")
+    void testShouldexistsByPermanentCredential_shouldReturnTrue() {
+        createUserWithProfile("11223344D", "Laura", "laura@example.com", "exists_cred");
+
+        boolean exists = profileRepository.existsByPermanentCredential("exists_cred");
+
+        assertThat(exists).isTrue();
+    }
+
 }

--- a/src/test/java/com/f5/buzon_inteligente_BE/profile/ProfileRepositoryIntegrationTest.java
+++ b/src/test/java/com/f5/buzon_inteligente_BE/profile/ProfileRepositoryIntegrationTest.java
@@ -1,0 +1,65 @@
+package com.f5.buzon_inteligente_BE.profile;
+
+import com.f5.buzon_inteligente_BE.roles.Role;
+import com.f5.buzon_inteligente_BE.roles.RoleRepository;
+import com.f5.buzon_inteligente_BE.user.User;
+import com.f5.buzon_inteligente_BE.user.UserRepository;
+import org.junit.jupiter.api.*;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.test.context.ActiveProfiles;
+
+import java.lang.reflect.Field;
+
+@DataJpaTest
+@ActiveProfiles("test")
+class ProfileRepositoryIntegrationTest {
+
+    @Autowired
+    private ProfileRepository profileRepository;
+
+    @Autowired
+    private UserRepository userRepository;
+
+    @Autowired
+    private RoleRepository roleRepository;
+
+    private Role defaultRole;
+
+    @BeforeEach
+    void setUp() {
+        defaultRole = createRole("USER");
+    }
+
+    @AfterEach
+    void tearDown() {
+        profileRepository.deleteAll();
+        userRepository.deleteAll();
+        roleRepository.deleteAll();
+    }
+
+    private User createUserWithProfile(String dni, String name, String email, String credential) {
+        User user = new User(dni, name, "Test", email, "test123", defaultRole);
+        user = userRepository.save(user);
+
+        Profile profile = new Profile();
+        profile.setUser(user);
+        profile.setPermanentCredential(credential);
+        profileRepository.save(profile);
+
+        return user;
+    }
+
+    private Role createRole(String roleName) {
+        Role role = new Role();
+        try {
+            Field field = Role.class.getDeclaredField("roleName");
+            field.setAccessible(true);
+            field.set(role, roleName);
+        } catch (Exception e) {
+            throw new RuntimeException("Failed to set roleName via reflection", e);
+        }
+        return roleRepository.save(role);
+    }
+
+}


### PR DESCRIPTION
## 📝 Descripción del Pull Request

Este PR añade una suite completa de tests de integración para la interfaz `ProfileRepository`, cubriendo tanto casos funcionales como casos límite (*edge cases*). Los tests se ejecutan utilizando H2 como base de datos en memoria mediante `@DataJpaTest`.

### ✅ Cambios realizados:

- Implementación de tests para los siguientes métodos del repositorio:
  - `findByUserUserId`
  - `existsByUserUserId`
  - `findByPermanentCredential`
  - `existsByPermanentCredential`
- Creación de un método helper `createUserWithProfile(...)` para reducir la duplicación de código.
- Uso de `@BeforeEach` para inicializar el `Role` por defecto.
- Uso de `@AfterEach` para limpiar la base de datos entre pruebas.
- Añadidos tests para **casos límite**, incluyendo:
  - `userId` nulo o inexistente.
  - `permanentCredential` nulo o vacío.
  - `userId` negativo.

### 🧪 Objetivo de los tests:

Asegurar que `ProfileRepository`:
- Funciona correctamente en condiciones normales.
- No lanza excepciones inesperadas ante entradas no válidas.
- Retorna valores coherentes (`Optional.empty`, `false`) en búsquedas fallidas.

[Test de Integración de la clase ProfileRepository](https://mabelrincon.atlassian.net/browse/TEST-55)

---
> **¡Se agradece cualquier feedback! Estoy encantada de hacer ajustes si consideran que hay aspectos que se pueden mejorar 😊**
