### PR TITLE
TEST-51 testing pull request 18 sub task test register service

### DIFF
--- a/src/test/java/com/f5/buzon_inteligente_BE/auth/register/RegisterServiceTest.java
+++ b/src/test/java/com/f5/buzon_inteligente_BE/auth/register/RegisterServiceTest.java
@@ -28,6 +28,8 @@ import com.f5.buzon_inteligente_BE.roles.Role;
 import com.f5.buzon_inteligente_BE.roles.RoleService;
 import com.f5.buzon_inteligente_BE.user.User;
 import com.f5.buzon_inteligente_BE.user.UserRepository;
+import com.f5.buzon_inteligente_BE.locker.LockerService;
+import com.f5.buzon_inteligente_BE.locker.Locker;
 
 @ExtendWith(MockitoExtension.class)
 public class RegisterServiceTest {
@@ -42,6 +44,9 @@ public class RegisterServiceTest {
 
     @Mock
     private RoleService roleService;
+
+    @Mock
+    private LockerService lockerService;
 
     @InjectMocks
     private RegisterService registerService;
@@ -75,6 +80,7 @@ public class RegisterServiceTest {
 
         when(roleService.getDefaultRole()).thenReturn(testRole);
         when(passwordEncoder.encode("Password")).thenReturn(encodedPassword);
+        when(lockerService.getRandomLocker()).thenReturn(Optional.of(new Locker()));
 
         User testUser = new User(
                 registerRequest.getUserDni(),
@@ -132,7 +138,7 @@ public class RegisterServiceTest {
 
         RegisterException exception = assertThrows(RegisterException.class,
                 () -> registerService.registerUser(registerRequest));
-                
+
         assertEquals("Error decoding password from Base64", exception.getMessage());
     }
         

--- a/src/test/java/com/f5/buzon_inteligente_BE/auth/register/RegisterServiceTest.java
+++ b/src/test/java/com/f5/buzon_inteligente_BE/auth/register/RegisterServiceTest.java
@@ -141,5 +141,20 @@ public class RegisterServiceTest {
 
         assertEquals("Error decoding password from Base64", exception.getMessage());
     }
-        
+    
+    @Test
+    @DisplayName("Should throw exception when there are no lockers available")
+    void testRegisterUserFailNoLockersAvailable() throws Exception, SecurityException {
+        when(userRepository.findByUserEmail("test@example.com")).thenReturn(Optional.empty());
+        when(userRepository.findByUserDni("DNI")).thenReturn(Optional.empty());
+
+        when(roleService.getDefaultRole()).thenReturn(testRole);
+        when(passwordEncoder.encode("Password")).thenReturn(encodedPassword);
+        when(lockerService.getRandomLocker()).thenReturn(Optional.empty());
+
+        RegisterException exception = assertThrows(RegisterException.class,
+                () -> registerService.registerUser(registerRequest));
+
+        assertEquals("No hay lockers disponibles para asignar", exception.getMessage());
+    }
 }

--- a/src/test/java/com/f5/buzon_inteligente_BE/auth/register/RegisterServiceTest.java
+++ b/src/test/java/com/f5/buzon_inteligente_BE/auth/register/RegisterServiceTest.java
@@ -1,31 +1,33 @@
 package com.f5.buzon_inteligente_BE.auth.register;
 
-import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 import java.lang.reflect.Field;
 import java.util.Base64;
 import java.util.Map;
 import java.util.Optional;
 
-
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
-
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.security.crypto.password.PasswordEncoder;
 
+import com.f5.buzon_inteligente_BE.auth.register.RegisterExceptions.DniAlreadyExistsException;
+import com.f5.buzon_inteligente_BE.auth.register.RegisterExceptions.EmailAlreadyExistsException;
+import com.f5.buzon_inteligente_BE.auth.register.RegisterExceptions.RegisterException;
 import com.f5.buzon_inteligente_BE.profile.ProfileService;
 import com.f5.buzon_inteligente_BE.roles.Role;
 import com.f5.buzon_inteligente_BE.roles.RoleService;
-import com.f5.buzon_inteligente_BE.user.UserRepository;
 import com.f5.buzon_inteligente_BE.user.User;
-
+import com.f5.buzon_inteligente_BE.user.UserRepository;
 
 @ExtendWith(MockitoExtension.class)
 public class RegisterServiceTest {
@@ -44,25 +46,43 @@ public class RegisterServiceTest {
     @InjectMocks
     private RegisterService registerService;
 
+    private RegisterRequest registerRequest;
+    private Role testRole;
+    private String encodedPassword;
+
+    @BeforeEach
+    public void setup() {
+        
+        encodedPassword = Base64.getEncoder().encodeToString("Password".getBytes());
+        registerRequest = new RegisterRequest(
+            "DNI", 
+            "Name",
+            "Surname",
+            "test@example.com",
+            encodedPassword
+        );
+
+        testRole = new Role("ROLE_USER");
+
+    }
+
     @Test
     @DisplayName("Should RegisterUser success")
     void testRegisterUserSuccess() throws Exception, SecurityException {
-        RegisterRequest registerRequest =  new RegisterRequest("DNI", "Name", "Surname", "test@example.com",  Base64.getEncoder().encodeToString("Password".getBytes()));
         
         when(userRepository.findByUserEmail("test@example.com")).thenReturn(Optional.empty());
         when(userRepository.findByUserDni("DNI")).thenReturn(Optional.empty());
 
-        Role testRole = new Role("ROLE_USER");
         when(roleService.getDefaultRole()).thenReturn(testRole);
-        when(passwordEncoder.encode("Password")).thenReturn(Base64.getEncoder().encodeToString("Password".getBytes()));
+        when(passwordEncoder.encode("Password")).thenReturn(encodedPassword);
 
         User testUser = new User(
-            registerRequest.getUserDni(),
-            registerRequest.getUserName(),
-            registerRequest.getUserSurname(),
-            registerRequest.getUserEmail(),
-            registerRequest.getUserPassword(),
-            testRole);
+                registerRequest.getUserDni(),
+                registerRequest.getUserName(),
+                registerRequest.getUserSurname(),
+                registerRequest.getUserEmail(),
+                registerRequest.getUserPassword(),
+                testRole);
 
         Field field = User.class.getDeclaredField("userId");
         field.setAccessible(true);
@@ -71,11 +91,49 @@ public class RegisterServiceTest {
         when(userRepository.save(any(User.class))).thenReturn(testUser);
 
         Map<String, String> result = registerService.registerUser(registerRequest);
-        
+
         assertEquals("Success", result.get("message"));
         verify(userRepository).save(any(User.class));
         verify(passwordEncoder).encode("Password");
         verify(roleService).getDefaultRole();
     }
-    
+
+    @Test
+    @DisplayName("Should RegisterUser fail because email already exists")
+    void testRegisterUserFailEmailAlreadyExists() throws Exception, SecurityException {
+        when(userRepository.findByUserEmail("test@example.com")).thenReturn(Optional.of(new User()));
+
+        EmailAlreadyExistsException exception = assertThrows(EmailAlreadyExistsException.class,
+                () -> registerService.registerUser(registerRequest));
+
+        verify(userRepository).findByUserEmail("test@example.com");
+        assertEquals("El email ya está registrado", exception.getMessage());
+    }
+
+    @Test
+    @DisplayName("Should RegisterUser fail because DNI already exists")
+    void testRegisterUserFailDniAlreadyExists() throws Exception, SecurityException {
+        when(userRepository.findByUserDni("DNI")).thenReturn(Optional.of(new User()));
+
+        DniAlreadyExistsException exception = assertThrows(DniAlreadyExistsException.class,
+                () -> registerService.registerUser(registerRequest));
+
+        verify(userRepository).findByUserDni("DNI");
+        assertEquals("El DNI ya está registrado", exception.getMessage());
+    }
+
+    @Test
+    @DisplayName("Should throw exception when password cannot be decoder")
+    void testRegisterUserFailPasswordCannotBeDecoder() throws Exception, SecurityException {
+        registerRequest.setUserPassword("###Password###");
+
+        when(userRepository.findByUserEmail("test@example.com")).thenReturn(Optional.empty());
+        when(userRepository.findByUserDni("DNI")).thenReturn(Optional.empty());
+
+        RegisterException exception = assertThrows(RegisterException.class,
+                () -> registerService.registerUser(registerRequest));
+                
+        assertEquals("Error decoding password from Base64", exception.getMessage());
+    }
+        
 }

--- a/src/test/java/com/f5/buzon_inteligente_BE/auth/register/RegisterServiceTest.java
+++ b/src/test/java/com/f5/buzon_inteligente_BE/auth/register/RegisterServiceTest.java
@@ -1,0 +1,81 @@
+package com.f5.buzon_inteligente_BE.auth.register;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+import java.lang.reflect.Field;
+import java.util.Base64;
+import java.util.Map;
+import java.util.Optional;
+
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import org.junit.jupiter.api.DisplayName;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.security.crypto.password.PasswordEncoder;
+
+import com.f5.buzon_inteligente_BE.profile.ProfileService;
+import com.f5.buzon_inteligente_BE.roles.Role;
+import com.f5.buzon_inteligente_BE.roles.RoleService;
+import com.f5.buzon_inteligente_BE.user.UserRepository;
+import com.f5.buzon_inteligente_BE.user.User;
+
+
+@ExtendWith(MockitoExtension.class)
+public class RegisterServiceTest {
+    @Mock
+    private UserRepository userRepository;
+
+    @Mock
+    private PasswordEncoder passwordEncoder;
+
+    @Mock
+    private ProfileService profileService;
+
+    @Mock
+    private RoleService roleService;
+
+    @InjectMocks
+    private RegisterService registerService;
+
+    @Test
+    @DisplayName("Should RegisterUser success")
+    void testRegisterUserSuccess() throws Exception, SecurityException {
+        RegisterRequest registerRequest =  new RegisterRequest("DNI", "Name", "Surname", "test@example.com",  Base64.getEncoder().encodeToString("Password".getBytes()));
+        
+        when(userRepository.findByUserEmail("test@example.com")).thenReturn(Optional.empty());
+        when(userRepository.findByUserDni("DNI")).thenReturn(Optional.empty());
+
+        Role testRole = new Role("ROLE_USER");
+        when(roleService.getDefaultRole()).thenReturn(testRole);
+        when(passwordEncoder.encode("Password")).thenReturn(Base64.getEncoder().encodeToString("Password".getBytes()));
+
+        User testUser = new User(
+            registerRequest.getUserDni(),
+            registerRequest.getUserName(),
+            registerRequest.getUserSurname(),
+            registerRequest.getUserEmail(),
+            registerRequest.getUserPassword(),
+            testRole);
+
+        Field field = User.class.getDeclaredField("userId");
+        field.setAccessible(true);
+        field.set(testUser, 1L);
+
+        when(userRepository.save(any(User.class))).thenReturn(testUser);
+
+        Map<String, String> result = registerService.registerUser(registerRequest);
+        
+        assertEquals("Success", result.get("message"));
+        verify(userRepository).save(any(User.class));
+        verify(passwordEncoder).encode("Password");
+        verify(roleService).getDefaultRole();
+    }
+    
+}


### PR DESCRIPTION
#### ✅ ¿Qué se ha hecho?

Se han añadido y refactorizado los tests unitarios de la clase `RegisterService` para cubrir los siguientes escenarios:

- Registro exitoso de un usuario nuevo con asignación de locker aleatorio.
    
- Excepciones lanzadas cuando:
    
    - El email ya está registrado.
    - El DNI ya existe en la base de datos.
    - La contraseña no puede ser decodificada desde Base64.
    - No hay lockers disponibles para asignar.
        

#### 🧪 Cobertura actual

- Verificación de comportamiento de los mocks `UserRepository`, `PasswordEncoder`, `RoleService`, `LockerService` y `ProfileService`.
    
- Se comprueba que:
    
    - Se llama correctamente a `passwordEncoder.encode(...)` con la contraseña decodificada.
    - Se lanza la excepción correspondiente según el flujo de error.
    - Se asigna un locker en el flujo exitoso.
        

#### 🔄 Refactor realizado

- Extracción de valores comunes en `@BeforeEach`.
    
- Cambio del test de éxito para reflejar la nueva lógica de `lockerService`.

[TEST-51 Testing Pull Request #18 - SubTask - Test RegisterService](https://mabelrincon.atlassian.net/browse/TEST-51?atlOrigin=eyJpIjoiZGIwMjgyYWE3N2Q1NDNiODg1MDU2Y2NjNTgxYmRjZmUiLCJwIjoiaiJ9)
