### PR TITLE
TEST-65 Refactorizacion de UserTest para integrar el atributo locker

### DIFF
--- a/src/test/java/com/f5/buzon_inteligente_BE/user/UserTest.java
+++ b/src/test/java/com/f5/buzon_inteligente_BE/user/UserTest.java
@@ -9,12 +9,14 @@ import org.junit.jupiter.api.Test;
 import java.lang.reflect.Field;
 
 import com.f5.buzon_inteligente_BE.roles.Role;
+import com.f5.buzon_inteligente_BE.locker.Locker;
 
 
 public class UserTest {
     
     private User user;
     private Role role;
+    private Locker locker;
 
     @BeforeEach
     void setUp() throws Exception{
@@ -23,6 +25,10 @@ public class UserTest {
         Field userIdField = User.class.getDeclaredField("userId");
         userIdField.setAccessible(true);
         userIdField.set(user, 1L);
+        Field lockerField = User.class.getDeclaredField("locker");
+        locker = new Locker();
+        lockerField.setAccessible(true);
+        lockerField.set(user, locker);
     }
 
     @Test
@@ -65,5 +71,11 @@ public class UserTest {
     @DisplayName("GetRole test case")
     void testGetRole() {
         assertEquals(role, user.getRole());
+    }
+
+    @Test
+    @DisplayName("GetLocker test case")
+    void testGetLocker() {
+        assertEquals(locker, user.getLocker());
     }
 }


### PR DESCRIPTION
Se ha añadido un test específico para el campo `locker` de la entidad `User`, asegurando que el método `getLocker()` funciona correctamente. Para ello, se ha creado una instancia de `Locker` en el `setUp()` del test y se ha asignado mediante reflexión.

**Cambios realizados:**

- Se ha creado una instancia de `Locker` dentro del método `setUp()` en `UserTest`.
- Se ha utilizado reflexión para asignar el objeto `locker` al campo privado `locker` de la clase `User`.
- Se ha añadido el test `testGetLocker()` que valida que el `getLocker()` devuelve correctamente el objeto `Locker` asignado.
- El resto de tests no se han modificado.

**Motivación:**  
Asegurar la cobertura del nuevo campo `locker` en la entidad `User` y verificar su correcta integración en la lógica existente.