### PR TITLE
TEST-25 Tests para la entidad `Locker`

### DIFF
--- a/src/test/java/com/f5/buzon_inteligente_BE/BuzonInteligenteBeApplicationTests.java
+++ b/src/test/java/com/f5/buzon_inteligente_BE/BuzonInteligenteBeApplicationTests.java
@@ -2,8 +2,10 @@ package com.f5.buzon_inteligente_BE;
 
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
 
 @SpringBootTest
+@ActiveProfiles("test")
 class BuzonInteligenteBeApplicationTests {
 
 	@Test

--- a/src/test/java/com/f5/buzon_inteligente_BE/locker/LockerTest.java
+++ b/src/test/java/com/f5/buzon_inteligente_BE/locker/LockerTest.java
@@ -9,6 +9,7 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
 import com.f5.buzon_inteligente_BE.mailbox.Mailbox;
+import com.f5.buzon_inteligente_BE.user.User;
 
 class LockerTest {
 
@@ -51,6 +52,17 @@ class LockerTest {
         List<Mailbox> mailboxes = locker.getMailboxes();
         assertThat(mailboxes).hasSize(1);
         assertThat(mailboxes.get(0)).isEqualTo(mailbox);
+    }
+
+    @Test
+    @DisplayName("Should users list be modifiable")
+    void testShouldAddUser() {
+        User user = new User();
+        locker.getUsers().add(user);
+
+        List<User> users = locker.getUsers();
+        assertThat(users).hasSize(1);
+        assertThat(users.get(0)).isEqualTo(user);
     }
 
 }

--- a/src/test/java/com/f5/buzon_inteligente_BE/locker/LockerTest.java
+++ b/src/test/java/com/f5/buzon_inteligente_BE/locker/LockerTest.java
@@ -79,4 +79,16 @@ class LockerTest {
         assertThat(locker.getLockerStatus()).isEqualTo(newStatus);
     }
 
+    @Test
+    @DisplayName("Should getMailboxes return empty list initially")
+    void testShouldGetMailboxesInitiallyEmpty() {
+        assertThat(locker.getMailboxes()).isEmpty();
+    }
+
+    @Test
+    @DisplayName("Should getUsers return empty list initially")
+    void testShouldGetUsersInitiallyEmpty() {
+        assertThat(locker.getUsers()).isEmpty();
+    }
+
 }

--- a/src/test/java/com/f5/buzon_inteligente_BE/locker/LockerTest.java
+++ b/src/test/java/com/f5/buzon_inteligente_BE/locker/LockerTest.java
@@ -65,4 +65,18 @@ class LockerTest {
         assertThat(users.get(0)).isEqualTo(user);
     }
 
+    @Test
+    @DisplayName("Should getTimeLimit return the correct value")
+    void testShouldGetTimeLimit() {
+        assertThat(locker.getTimeLimit()).isEqualTo(48L);
+    }
+
+    @Test
+    @DisplayName("Should setLockerStatus assign the correct status")
+    void testShouldSetLockerStatus() {
+        LockerStatus newStatus = new LockerStatus();
+        locker.setLockerStatus(newStatus);
+        assertThat(locker.getLockerStatus()).isEqualTo(newStatus);
+    }
+
 }

--- a/src/test/java/com/f5/buzon_inteligente_BE/locker/LockerTest.java
+++ b/src/test/java/com/f5/buzon_inteligente_BE/locker/LockerTest.java
@@ -1,7 +1,11 @@
 package com.f5.buzon_inteligente_BE.locker;
 
 
+import static org.assertj.core.api.Assertions.*;
+
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
 
 
 class LockerTest {
@@ -14,5 +18,13 @@ class LockerTest {
         lockerStatus = new LockerStatus();
         locker = new Locker("Calle 123", 48L, lockerStatus);
     } 
+
+    @Test
+    @DisplayName("Should constructor set address, timeLimit and lockerStatus correctly")
+    void testShouldConstructor() {
+        assertThat(locker.getAddress()).isEqualTo("Calle 123");
+        assertThat(locker.getTimeLimit()).isEqualTo(48L);
+        assertThat(locker.getLockerStatus()).isEqualTo(lockerStatus);
+    }
 
 }

--- a/src/test/java/com/f5/buzon_inteligente_BE/locker/LockerTest.java
+++ b/src/test/java/com/f5/buzon_inteligente_BE/locker/LockerTest.java
@@ -27,4 +27,19 @@ class LockerTest {
         assertThat(locker.getLockerStatus()).isEqualTo(lockerStatus);
     }
 
+      
+
+    @Test
+    @DisplayName("Should Setters and Getters  work correctly")
+    void testShouldSettersAndGetters() {
+        locker.setAddress("Nueva dirección");
+        locker.setTimeLimit(72L);
+        LockerStatus newStatus = new LockerStatus();
+        locker.setLockerStatus(newStatus);
+
+        assertThat(locker.getAddress()).isEqualTo("Nueva dirección");
+        assertThat(locker.getTimeLimit()).isEqualTo(72L);
+        assertThat(locker.getLockerStatus()).isEqualTo(newStatus);
+    }
+
 }

--- a/src/test/java/com/f5/buzon_inteligente_BE/locker/LockerTest.java
+++ b/src/test/java/com/f5/buzon_inteligente_BE/locker/LockerTest.java
@@ -1,0 +1,18 @@
+package com.f5.buzon_inteligente_BE.locker;
+
+
+import org.junit.jupiter.api.BeforeEach;
+
+
+class LockerTest {
+
+    private Locker locker;
+    private LockerStatus lockerStatus;
+
+    @BeforeEach
+    void setUp() {
+        lockerStatus = new LockerStatus();
+        locker = new Locker("Calle 123", 48L, lockerStatus);
+    } 
+
+}

--- a/src/test/java/com/f5/buzon_inteligente_BE/locker/LockerTest.java
+++ b/src/test/java/com/f5/buzon_inteligente_BE/locker/LockerTest.java
@@ -1,12 +1,14 @@
 package com.f5.buzon_inteligente_BE.locker;
 
-
 import static org.assertj.core.api.Assertions.*;
+
+import java.util.List;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
+import com.f5.buzon_inteligente_BE.mailbox.Mailbox;
 
 class LockerTest {
 
@@ -17,7 +19,7 @@ class LockerTest {
     void setUp() {
         lockerStatus = new LockerStatus();
         locker = new Locker("Calle 123", 48L, lockerStatus);
-    } 
+    }
 
     @Test
     @DisplayName("Should constructor set address, timeLimit and lockerStatus correctly")
@@ -26,8 +28,6 @@ class LockerTest {
         assertThat(locker.getTimeLimit()).isEqualTo(48L);
         assertThat(locker.getLockerStatus()).isEqualTo(lockerStatus);
     }
-
-      
 
     @Test
     @DisplayName("Should Setters and Getters  work correctly")
@@ -40,6 +40,17 @@ class LockerTest {
         assertThat(locker.getAddress()).isEqualTo("Nueva dirección");
         assertThat(locker.getTimeLimit()).isEqualTo(72L);
         assertThat(locker.getLockerStatus()).isEqualTo(newStatus);
+    }
+
+    @Test
+    @DisplayName("Should mailboxes list be modifiable")
+    void testShouldAddMailbox() {
+        Mailbox mailbox = new Mailbox();
+        locker.getMailboxes().add(mailbox);
+
+        List<Mailbox> mailboxes = locker.getMailboxes();
+        assertThat(mailboxes).hasSize(1);
+        assertThat(mailboxes.get(0)).isEqualTo(mailbox);
     }
 
 }


### PR DESCRIPTION
## ✅ Descripción del PR

### 🧪 Tests unitarios para la entidad `Locker`

Este Pull Request agrega tests unitarios para la clase `Locker`, con el objetivo de asegurar el correcto funcionamiento de sus métodos y relaciones asociadas como parte del módulo `locker`.

---

### 🔍 ¿Qué cubre este PR?

- Verificación del constructor: `address`, `timeLimit`, `lockerStatus`.
- Comprobación de los métodos **getters y setters**.
- Pruebas sobre la mutabilidad de las listas:
  - `mailboxes`
  - `users`
- Comprobación de valores iniciales (listas vacías).
- Validación del valor retornado por `getTimeLimit()` y la correcta asignación con `setLockerStatus()`.

---

### 📈 Cobertura alcanzada

> Se alcanza una cobertura del **93.75%** en la clase `Locker`.  
> Solo queda pendiente la cobertura del método `getLockerId()`, el cual requiere test de integración al depender de persistencia con JPA.

[TEST-25 Tests para la entidad `Locker`](https://mabelrincon.atlassian.net/browse/TEST-25)

---
> **¡Se agradece cualquier feedback! Estoy encantada de hacer ajustes si consideran que hay aspectos que se pueden mejorar 😊**