### PR TITLE
TEST-69 🛠️ Fix: Include userId in JWT token generation and update related tests

### DIFF
--- a/src/test/java/com/f5/buzon_inteligente_BE/auth/login/LoginServiceTest.java
+++ b/src/test/java/com/f5/buzon_inteligente_BE/auth/login/LoginServiceTest.java
@@ -43,11 +43,12 @@ public class LoginServiceTest {
         String encodedPassword = Base64.getEncoder().encodeToString(password.getBytes());
         LoginRequestDto request = new LoginRequestDto(email, encodedPassword);
 
+        when(userDetails.getUserId()).thenReturn(1L);
         when(userDetails.getUsername()).thenReturn(email);
         when(userDetails.getRole()).thenReturn(role);
         when(userDetails.getDni()).thenReturn(dni);
 
-        when(jwtUtils.generateJwtToken(email, role, dni)).thenReturn("token");
+        when(jwtUtils.generateJwtToken(email, role, dni, 1L)).thenReturn("token");
 
         UsernamePasswordAuthenticationToken authentication = new UsernamePasswordAuthenticationToken(userDetails, password);
         when(authenticationManager.authenticate(any())).thenReturn(authentication);

--- a/src/test/java/com/f5/buzon_inteligente_BE/security/CustomUserDetailsServiceTest.java
+++ b/src/test/java/com/f5/buzon_inteligente_BE/security/CustomUserDetailsServiceTest.java
@@ -17,6 +17,7 @@ import static org.mockito.Mockito.*;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.security.core.userdetails.UsernameNotFoundException;
+import org.springframework.test.util.ReflectionTestUtils;
 
 import com.f5.buzon_inteligente_BE.user.User;
 import com.f5.buzon_inteligente_BE.user.UserRepository;
@@ -36,16 +37,18 @@ public class CustomUserDetailsServiceTest {
     @DisplayName("Test load user by email")
     void testLoadUserByEmail() {
         Role role = new Role("USER");
-        User user = new User("12345678X", "test", "example", "test@example.com", "password123", role);
-
+        User user = new User( "12345678X", "test", "example", "test@example.com", "password123", role);
+        ReflectionTestUtils.setField(user, "userId", 1L);
+    
         when(userRepository.findByUserEmail("test@example.com")).thenReturn(Optional.of(user));
-
+    
         UserDetails userDetails = customUserDetailsService.loadUserByUsername("test@example.com");
-        
+    
         assertEquals("test@example.com", userDetails.getUsername());
         assertEquals("password123", userDetails.getPassword());
         assertTrue(userDetails.isEnabled());
     }
+    
     
     @Test
     @DisplayName("Test load user by email don't exist")

--- a/src/test/java/com/f5/buzon_inteligente_BE/security/CustomUserDetailsTest.java
+++ b/src/test/java/com/f5/buzon_inteligente_BE/security/CustomUserDetailsTest.java
@@ -6,64 +6,83 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import java.util.Collection;
 
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.core.authority.SimpleGrantedAuthority;
 
+@DisplayName("CustomUserDetails Unit Tests")
 public class CustomUserDetailsTest {
 
     private CustomUserDetails userDetails;
+
     @BeforeEach
     void setUp() {
-        userDetails = new CustomUserDetails("DefaultUSer", "DefaultPassword", "USER", "DefaultDni", true);
+        userDetails = new CustomUserDetails(1L, "DefaultUSer", "DefaultPassword", "USER", "DefaultDni", true);
     }
+
     @Test
-    void testGetAuthorities() {
+    @DisplayName("Should return correct authorities with ROLE prefix")
+    void testShouldGetAuthorities() {
         Collection<? extends GrantedAuthority> authorities = userDetails.getAuthorities();
 
         assertEquals(1, authorities.size());
         assertEquals("ROLE_USER", authorities.iterator().next().getAuthority());
         assertTrue(authorities.iterator().next() instanceof SimpleGrantedAuthority);
-
     }
 
     @Test
-    void testGetDni() {
+    @DisplayName("Should return correct DNI")
+    void testShouldGetDni() {
         assertEquals("DefaultDni", userDetails.getDni());
     }
 
     @Test
-    void testGetPassword() {
-        assertEquals("DefaultPassword", userDetails.getPassword());   
+    @DisplayName("Should return correct password")
+    void testShouldGetPassword() {
+        assertEquals("DefaultPassword", userDetails.getPassword());
     }
 
     @Test
+    @DisplayName("Should return correct role")
     void testGetRole() {
         assertEquals("USER", userDetails.getRole());
     }
 
     @Test
-    void testGetUsername() {
+    @DisplayName("Should return correct username")
+    void testShouldGetUsername() {
         assertEquals("DefaultUSer", userDetails.getUsername());
     }
 
     @Test
-    void testIsAccountNonExpired() {
+    @DisplayName("Should return account as non-expired")
+    void testShouldIsAccountNonExpired() {
         assertEquals(true, userDetails.isAccountNonExpired());
     }
 
     @Test
-    void testIsAccountNonLocked() {
+    @DisplayName("Should return account as non-locked")
+    void testShouldIsAccountNonLocked() {
         assertEquals(true, userDetails.isAccountNonLocked());
     }
 
     @Test
-    void testIsCredentialsNonExpired() {
+    @DisplayName("Should return credentials as non-expired")
+    void testShouldIsCredentialsNonExpired() {
         assertEquals(true, userDetails.isCredentialsNonExpired());
     }
 
     @Test
-    void testIsEnabled() {
+    @DisplayName("Should return account as enabled")
+    void testShouldIsEnabled() {
         assertEquals(true, userDetails.isEnabled());
     }
+
+    @Test
+    @DisplayName("Should return correct userId")
+    void testShouldGetUserId() {
+        assertEquals(1L, userDetails.getUserId());
+    }
 }
+

--- a/src/test/java/com/f5/buzon_inteligente_BE/security/JwtUtilsTest.java
+++ b/src/test/java/com/f5/buzon_inteligente_BE/security/JwtUtilsTest.java
@@ -40,13 +40,13 @@ public class JwtUtilsTest {
                 "mZBZfP8L99Zm8GDZCBoBPXaGNsq4CPGK/c/pX9nuSUXwxLBzME2YkdE+5EYXPLkP54x32MmNljQIgGhD4oM3Hg==");
         ReflectionTestUtils.setField(jwtUtils, "jwtExpirationMs", 3600000);
 
-        validToken = jwtUtils.generateJwtToken(username, role, dni);
+        validToken = jwtUtils.generateJwtToken(username, role, dni, 1L);
     }
 
     @Test
     @DisplayName("Should generate a non-null JWT token")
     public void testShouldGenerateNonNullJwtToken() {
-        String token = jwtUtils.generateJwtToken(username, role, dni);
+        String token = jwtUtils.generateJwtToken(username, role, dni, 1L);
         assertNotNull(token, "Generated token should not be null");
     }
 
@@ -71,7 +71,7 @@ public class JwtUtilsTest {
     @DisplayName("Should detect expired JWT token")
     public void testShouldDetectExpiredJwtToken() throws InterruptedException {
         ReflectionTestUtils.setField(jwtUtils, "jwtExpirationMs", 1);
-        String shortLivedToken = jwtUtils.generateJwtToken(username, role, dni);
+        String shortLivedToken = jwtUtils.generateJwtToken(username, role, dni,1L);
 
         Thread.sleep(10);
 


### PR DESCRIPTION
## 🛠️ Fix: Include userId in JWT token generation and update related tests

### 📋 Descripción

Este Pull Request soluciona un error relacionado con la generación del token JWT en el proceso de autenticación, donde no se estaba incluyendo correctamente el parámetro `userId`, lo que causaba un `PotentialStubbingProblem` en los tests con Mockito.

### ✅ Cambios realizados

- Se agregó `userId` al mock de `CustomUserDetails` en el test `testAuthenticate()`:
  ```java
  when(userDetails.getUserId()).thenReturn(1L);

- Se actualizó la llamada mockeada a jwtUtils.generateJwtToken(...) para que coincida con los argumentos reales utilizados:
  ```java
  when(jwtUtils.generateJwtToken(email, role, dni, 1L)).thenReturn("token");

- Se mejoró la legibilidad general de los tests añadiendo @DisplayName.

- Se resolvió el error:
   ```java
     org.mockito.exceptions.misusing.PotentialStubbingProblem:
    Strict stubbing argument mismatch


📌 Notas adicionales
Este fix asegura que el userId sea correctamente manejado en la autenticación, tanto en el servicio como en los tests unitarios. Esto garantiza la correcta generación del JWT y mejora la cobertura y fiabilidad del sistema de autenticación.