### PR TITLE
TEST-48 Test register controller

### DIFF
--- a/src/test/java/com/f5/buzon_inteligente_BE/auth/register/RegisterControllerTest.java
+++ b/src/test/java/com/f5/buzon_inteligente_BE/auth/register/RegisterControllerTest.java
@@ -22,12 +22,12 @@ import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
 
-import com.f5.buzon_inteligente_BE.auth.register.RegisterExceptions.EmailAlreadyExistsException;
 import com.f5.buzon_inteligente_BE.auth.register.RegisterExceptions.DniAlreadyExistsException;
+import com.f5.buzon_inteligente_BE.auth.register.RegisterExceptions.EmailAlreadyExistsException;
+import com.f5.buzon_inteligente_BE.auth.register.RegisterExceptions.RegisterException;
 import com.f5.buzon_inteligente_BE.security.JwtUtils;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
-
 
 @WebMvcTest(RegisterController.class)
 @ActiveProfiles("test")
@@ -51,20 +51,21 @@ public class RegisterControllerTest {
     @BeforeEach
     public void setup() throws JsonProcessingException {
         registerRequest = new RegisterRequest("12345678", "name", "surname", "email@example.com", "password");
-        json=objectMapper.writeValueAsString(registerRequest);
+        json = objectMapper.writeValueAsString(registerRequest);
     }
+
     @Test
     @DisplayName("Should registerUser success")
-    public void shouldRegisterUserSuccess() throws Exception {        
+    public void shouldRegisterUserSuccess() throws Exception {
         when(registerService.registerUser(any(RegisterRequest.class)))
-                            .thenReturn(Map.of("message", "Success"));
+                .thenReturn(Map.of("message", "Success"));
 
         MockHttpServletResponse response = mockMvc.perform(post("/api/auth/register")
-            .contentType(MediaType.APPLICATION_JSON)
-            .content(json)) 
-            .andExpect(status().isCreated())
-            .andReturn()
-            .getResponse();
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(json))
+                .andExpect(status().isCreated())
+                .andReturn()
+                .getResponse();
 
         assertThat(response.getStatus(), is(201));
         assertThat(response.getContentType(), is("application/json"));
@@ -73,38 +74,69 @@ public class RegisterControllerTest {
 
     @Test
     @DisplayName("Should registerUser fail email already exists")
-    public void shouldRegisterUserFailEmailAlreadyExists() throws Exception {      
+    public void shouldRegisterUserFailEmailAlreadyExists() throws Exception {
         when(registerService.registerUser(any(RegisterRequest.class)))
-                            .thenThrow(new EmailAlreadyExistsException("Email already exists"));
+                .thenThrow(new EmailAlreadyExistsException("Email already exists"));
 
         MockHttpServletResponse response = mockMvc.perform(post("/api/auth/register")
-            .contentType(MediaType.APPLICATION_JSON)
-            .content(json)) 
-            .andExpect(status().isBadRequest())
-            .andReturn()
-            .getResponse();
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(json))
+                .andExpect(status().isBadRequest())
+                .andReturn()
+                .getResponse();
 
-        assertThat(response.getStatus(), is(400));        
-        assertThat(response.getContentAsString(),containsString("Email already exists"));
+        assertThat(response.getStatus(), is(400));
+        assertThat(response.getContentAsString(), containsString("Email already exists"));
     }
 
     @Test
     @DisplayName("Should registerUser fail DNI already exists")
-    public void shouldRegisterUserFailDniAlreadyExists() throws Exception {      
+    public void shouldRegisterUserFailDniAlreadyExists() throws Exception {
         when(registerService.registerUser(any(RegisterRequest.class)))
-                            .thenThrow(new DniAlreadyExistsException("DNI already exists"));
+                .thenThrow(new DniAlreadyExistsException("DNI already exists"));
 
         MockHttpServletResponse response = mockMvc.perform(post("/api/auth/register")
-            .contentType(MediaType.APPLICATION_JSON)
-            .content(json)) 
-            .andExpect(status().isBadRequest())
-            .andReturn()    
-            .getResponse();
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(json))
+                .andExpect(status().isBadRequest())
+                .andReturn()
+                .getResponse();
 
-        assertThat(response.getStatus(), is(400));        
-        assertThat(response.getContentAsString(),containsString("DNI already exists"));
+        assertThat(response.getStatus(), is(400));
+        assertThat(response.getContentAsString(), containsString("DNI already exists"));
     }
 
     @Test
-    @DisplayName("Should registerUser fail ")
+    @DisplayName("Should registerUser fail register")
+    public void shouldRegisterUserFailRegister() throws Exception {
+        when(registerService.registerUser(any(RegisterRequest.class)))
+                .thenThrow(new RegisterException("Register error"));
+
+        MockHttpServletResponse response = mockMvc.perform(post("/api/auth/register")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(json))
+                .andExpect(status().isInternalServerError())
+                .andReturn()
+                .getResponse();
+
+        assertThat(response.getStatus(), is(500));
+        assertThat(response.getContentAsString(), containsString("Register error"));
+    }
+
+    @Test
+    @DisplayName("Should registerUser fail exception")
+    public void shouldRegisterUserFailException() throws Exception {
+        when(registerService.registerUser(any(RegisterRequest.class)))
+                .thenThrow(new RuntimeException("Unexpected error"));
+
+        MockHttpServletResponse response = mockMvc.perform(post("/api/auth/register")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(json))
+                .andExpect(status().isInternalServerError())
+                .andReturn()
+                .getResponse();
+
+        assertThat(response.getStatus(), is(500));
+        assertThat(response.getContentAsString(), containsString("Unexpected error"));
+    }
 }

--- a/src/test/java/com/f5/buzon_inteligente_BE/auth/register/RegisterControllerTest.java
+++ b/src/test/java/com/f5/buzon_inteligente_BE/auth/register/RegisterControllerTest.java
@@ -1,6 +1,7 @@
 package com.f5.buzon_inteligente_BE.auth.register;
 
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.core.Is.is;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.when;
@@ -9,6 +10,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 
 import java.util.Map;
 
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -20,7 +22,10 @@ import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
 
+import com.f5.buzon_inteligente_BE.auth.register.RegisterExceptions.EmailAlreadyExistsException;
+import com.f5.buzon_inteligente_BE.auth.register.RegisterExceptions.DniAlreadyExistsException;
 import com.f5.buzon_inteligente_BE.security.JwtUtils;
+import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 
 
@@ -40,15 +45,19 @@ public class RegisterControllerTest {
     @Autowired
     ObjectMapper objectMapper;
 
+    private RegisterRequest registerRequest;
+    private String json;
+
+    @BeforeEach
+    public void setup() throws JsonProcessingException {
+        registerRequest = new RegisterRequest("12345678", "name", "surname", "email@example.com", "password");
+        json=objectMapper.writeValueAsString(registerRequest);
+    }
     @Test
     @DisplayName("Should registerUser success")
-    public void shouldRegisterUserSuccess() throws Exception {
-        RegisterRequest registerRequest = new RegisterRequest("12345678", "name", "surname", "email@example.com", "password");
-        
+    public void shouldRegisterUserSuccess() throws Exception {        
         when(registerService.registerUser(any(RegisterRequest.class)))
                             .thenReturn(Map.of("message", "Success"));
-
-        String json=objectMapper.writeValueAsString(registerRequest);
 
         MockHttpServletResponse response = mockMvc.perform(post("/api/auth/register")
             .contentType(MediaType.APPLICATION_JSON)
@@ -61,4 +70,41 @@ public class RegisterControllerTest {
         assertThat(response.getContentType(), is("application/json"));
         assertThat(response.getContentAsString(), is("{\"message\":\"Success\"}"));
     }
+
+    @Test
+    @DisplayName("Should registerUser fail email already exists")
+    public void shouldRegisterUserFailEmailAlreadyExists() throws Exception {      
+        when(registerService.registerUser(any(RegisterRequest.class)))
+                            .thenThrow(new EmailAlreadyExistsException("Email already exists"));
+
+        MockHttpServletResponse response = mockMvc.perform(post("/api/auth/register")
+            .contentType(MediaType.APPLICATION_JSON)
+            .content(json)) 
+            .andExpect(status().isBadRequest())
+            .andReturn()
+            .getResponse();
+
+        assertThat(response.getStatus(), is(400));        
+        assertThat(response.getContentAsString(),containsString("Email already exists"));
+    }
+
+    @Test
+    @DisplayName("Should registerUser fail DNI already exists")
+    public void shouldRegisterUserFailDniAlreadyExists() throws Exception {      
+        when(registerService.registerUser(any(RegisterRequest.class)))
+                            .thenThrow(new DniAlreadyExistsException("DNI already exists"));
+
+        MockHttpServletResponse response = mockMvc.perform(post("/api/auth/register")
+            .contentType(MediaType.APPLICATION_JSON)
+            .content(json)) 
+            .andExpect(status().isBadRequest())
+            .andReturn()    
+            .getResponse();
+
+        assertThat(response.getStatus(), is(400));        
+        assertThat(response.getContentAsString(),containsString("DNI already exists"));
+    }
+
+    @Test
+    @DisplayName("Should registerUser fail ")
 }

--- a/src/test/java/com/f5/buzon_inteligente_BE/auth/register/RegisterControllerTest.java
+++ b/src/test/java/com/f5/buzon_inteligente_BE/auth/register/RegisterControllerTest.java
@@ -1,0 +1,64 @@
+package com.f5.buzon_inteligente_BE.auth.register;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.core.Is.is;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import java.util.Map;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.http.MediaType;
+import org.springframework.mock.web.MockHttpServletResponse;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+import com.f5.buzon_inteligente_BE.security.JwtUtils;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+
+@WebMvcTest(RegisterController.class)
+@ActiveProfiles("test")
+@AutoConfigureMockMvc(addFilters = false)
+public class RegisterControllerTest {
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockitoBean
+    private RegisterService registerService;
+
+    @MockitoBean
+    private JwtUtils jwtUtils;
+
+    @Autowired
+    ObjectMapper objectMapper;
+
+    @Test
+    @DisplayName("Should registerUser success")
+    public void shouldRegisterUserSuccess() throws Exception {
+        RegisterRequest registerRequest = new RegisterRequest("12345678", "name", "surname", "email@example.com", "password");
+        
+        when(registerService.registerUser(any(RegisterRequest.class)))
+                            .thenReturn(Map.of("message", "Success"));
+
+        String json=objectMapper.writeValueAsString(registerRequest);
+
+        MockHttpServletResponse response = mockMvc.perform(post("/api/auth/register")
+            .contentType(MediaType.APPLICATION_JSON)
+            .content(json)) 
+            .andExpect(status().isCreated())
+            .andReturn()
+            .getResponse();
+
+        assertThat(response.getStatus(), is(201));
+        assertThat(response.getContentType(), is("application/json"));
+        assertThat(response.getContentAsString(), is("{\"message\":\"Success\"}"));
+    }
+}


### PR DESCRIPTION
Se añade una batería completa de tests unitarios para el `RegisterController` utilizando `@WebMvcTest`, cubriendo tanto casos exitosos como de error. Los tests verifican el comportamiento esperado del endpoint `/api/auth/register` ante distintos escenarios controlados y excepciones inesperadas.

---

### ✅ **Cambios incluidos:**

- **Test de registro exitoso**: verifica que se retorna `201 Created` con la respuesta esperada.
    
- **Test cuando el email ya existe**: simula una `EmailAlreadyExistsException` y espera `400 Bad Request`.
    
- **Test cuando el DNI ya existe**: simula una `DniAlreadyExistsException` y espera `400 Bad Request`.
    
- **Test con fallo de registro genérico**: simula una `RegisterException` y espera `500 Internal Server Error`.
    
- **Test con excepción inesperada**: simula una `RuntimeException` y verifica la gestión mediante el bloque `catch (Exception)`.

---

### 🔒 Seguridad:

- `@AutoConfigureMockMvc(addFilters = false)` se usa para desactivar filtros de seguridad durante los tests y evitar interferencias externas como el filtro JWT.