### PR TITLE
TEST-46 MailboxStatus getters y setters test working

### DIFF
--- a/src/test/java/com/f5/buzon_inteligente_BE/mailbox/MailboxStatusTest.java
+++ b/src/test/java/com/f5/buzon_inteligente_BE/mailbox/MailboxStatusTest.java
@@ -1,0 +1,41 @@
+package com.f5.buzon_inteligente_BE.mailbox;
+
+import java.lang.reflect.Field;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class MailboxStatusTest {
+
+    MailboxStatus mailboxStatus;
+    @BeforeEach
+    public void setup() throws NoSuchFieldException, SecurityException, IllegalAccessException  {
+        mailboxStatus = new MailboxStatus("FREE");
+        Field mailboxStatusIdField = MailboxStatus.class.getDeclaredField("mailboxStatusId");
+        mailboxStatusIdField.setAccessible(true);
+        mailboxStatusIdField.set(mailboxStatus, 1L);
+        
+    }
+    @Test
+    @DisplayName("getMailboxStatusId test")
+    public void getMailboxStatusIdTest() {
+        assertThat(mailboxStatus.getMailboxStatusId()).isEqualTo(1L);
+    }
+
+    @Test
+    @DisplayName("getMailboxStatusName test")
+    public void getMailboxStatusNameTest() {
+        assertThat(mailboxStatus.getMailboxStatusName()).isEqualTo("FREE");
+    }
+
+    @Test
+    @DisplayName("setMailboxStatusName test")
+    public void setMailboxStatusNameTest() {
+        mailboxStatus.setMailboxStatusName("USED");
+        assertThat(mailboxStatus.getMailboxStatusName()).isEqualTo("USED");
+    }
+
+}


### PR DESCRIPTION
#### ✅ Cambios realizados:

- Se crea una instancia de `MailboxStatus` en cada test utilizando su constructor con el parámetro `mailboxStatusName`.
- Se establece el valor del campo privado `mailboxStatusId` mediante reflexión para poder verificar su getter.
- Se implementan los siguientes tests unitarios:
    - `getMailboxStatusIdTest`: Verifica que el getter de `mailboxStatusId` devuelva el valor esperado.
    - `getMailboxStatusNameTest`: Verifica que el getter de `mailboxStatusName` funcione correctamente.
    - `setMailboxStatusNameTest`: Verifica que el setter de `mailboxStatusName` actualice correctamente el valor.

#### 🧪 Cobertura:

- La clase cubre las funcionalidades básicas de la entidad `MailboxStatus`, asegurando el correcto funcionamiento de sus getters y setters.