### PR TITLE
TEST-59 MailboxSize getters y setters test working

### DIFF
--- a/src/test/java/com/f5/buzon_inteligente_BE/mailbox/MailboxSizeTest.java
+++ b/src/test/java/com/f5/buzon_inteligente_BE/mailbox/MailboxSizeTest.java
@@ -1,0 +1,42 @@
+package com.f5.buzon_inteligente_BE.mailbox;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.BeforeEach;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+import java.lang.reflect.Field;
+
+public class MailboxSizeTest {
+    
+    private MailboxSize mailboxSize;
+
+    @BeforeEach
+    void setUp() throws NoSuchFieldException, IllegalAccessException {
+        mailboxSize = new MailboxSize("LARGE");
+        Field mailboxSizeId = MailboxSize.class.getDeclaredField("mailboxSizeId");
+        mailboxSizeId.setAccessible(true);
+        mailboxSizeId.set(mailboxSize, 1L);
+    }
+
+    @Test
+    @DisplayName("getMailboxSizeId test")
+    void testGetMailboxSizeId() {
+        assertThat(mailboxSize.getMailboxSizeId(), is(1L));    
+    }
+
+    @Test
+    @DisplayName("setMailboxSizeId test")
+    void testGetMailboxSizeName() {
+        assertThat(mailboxSize.getMailboxSizeName(), is("LARGE"));
+    }
+
+    @Test
+    @DisplayName("setMailboxSizeName test")
+    void testSetMailboxSizeName() {
+        mailboxSize.setMailboxSizeName("SMALL");
+        assertThat(mailboxSize.getMailboxSizeName(), is("SMALL"));  
+    }
+}


### PR DESCRIPTION
Se añade la clase de test `MailboxStatusTest` para cubrir los métodos públicos de la entidad `MailboxStatus`.

Se añade la clase de pruebas `MailboxSizeTest` para verificar el comportamiento de la entidad `MailboxSize`.

#### 🧪 Cobertura de tests:

- **`testGetMailboxSizeId`**: Verifica que el método `getMailboxSizeId()` devuelva correctamente el identificador asignado mediante reflexión.
    
- **`testGetMailboxSizeName`**: Comprueba que el getter `getMailboxSizeName()` devuelva el nombre asignado en el constructor.
    
- **`testSetMailboxSizeName`**: Verifica que el setter `setMailboxSizeName()` actualiza correctamente el valor.

[TEST-59 Testing Pull Request #34 - Buz 162 crear entidad mailbox sizes](https://mabelrincon.atlassian.net/browse/TEST-59)