### PR TITLE
TEST-62 Mailbox getters y setters test

### DIFF
--- a/src/test/java/com/f5/buzon_inteligente_BE/mailbox/MailboxTest.java
+++ b/src/test/java/com/f5/buzon_inteligente_BE/mailbox/MailboxTest.java
@@ -1,0 +1,81 @@
+package com.f5.buzon_inteligente_BE.mailbox;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.CoreMatchers.is;
+
+import java.lang.reflect.Field;
+
+import com.f5.buzon_inteligente_BE.locker.Locker;
+
+public class MailboxTest {
+
+    private Mailbox mailbox;
+    private MailboxSize mailboxSize;
+    private MailboxStatus mailboxStatus;
+    private Locker locker;
+
+
+    @BeforeEach
+    void setUp() throws Exception {
+        mailboxSize = new MailboxSize("LARGE");
+        mailboxStatus = new MailboxStatus("FREE");
+        locker = new Locker();
+        mailbox = new Mailbox(mailboxSize, locker, mailboxStatus, 42);
+
+        Field mailboxIdField = Mailbox.class.getDeclaredField("mailboxId");
+        mailboxIdField.setAccessible(true);
+        mailboxIdField.set(mailbox, 1L);
+    }
+
+    @Test
+    @DisplayName("GetLocker test")
+    void testGetLocker() {
+        assertThat(mailbox.getLocker(), is(locker));
+    }
+
+    @Test
+    @DisplayName("GetMailboxId test")
+    void testGetMailboxId() {
+        assertThat(mailbox.getMailboxId(), is(1L));
+    }
+
+    @Test
+    @DisplayName("GetMailboxNumber test")
+    void testGetMailboxNumber() {
+        assertThat(mailbox.getMailboxNumber(), is(42));
+    }
+
+    @Test
+    @DisplayName("GetMailboxSize test")
+    void testGetMailboxSize() {
+        assertThat(mailbox.getMailboxSize(), is(mailboxSize));
+    }
+
+    @Test
+    @DisplayName("GetMailboxStatus test")
+    void testGetMailboxStatus() {
+        assertThat(mailbox.getMailboxStatus(), is(mailboxStatus));
+    }
+
+    @Test
+    void testSetMailboxNumber() {
+        mailbox.setMailboxNumber(43);
+        assertThat(mailbox.getMailboxNumber(), is(43));
+    }
+
+    @Test
+    void testSetMailboxSize() {
+        mailbox.setMailboxSize(new MailboxSize("SMALL"));
+        assertThat(mailbox.getMailboxSize().getMailboxSizeName(), is("SMALL"));
+    }
+
+    @Test
+    void testSetMailboxStatus() {
+        mailbox.setMailboxStatus(new MailboxStatus("BUSY"));
+        assertThat(mailbox.getMailboxStatus().getMailboxStatusName(), is("BUSY"));
+    }
+}


### PR DESCRIPTION
Se añade la clase de test `MailboxTest` para verificar el correcto funcionamiento de la entidad `Mailbox`.

#### 🧪 Cobertura de pruebas:

- **`testGetLocker`**: Comprueba que el método `getLocker()` devuelve el objeto `Locker` asociado.
- **`testGetMailboxId`**: Verifica que el método `getMailboxId()` devuelve correctamente el ID asignado mediante reflexión.
- **`testGetMailboxNumber`**: Comprueba que el método `getMailboxNumber()` devuelve el número de buzón asignado.    
- **`testGetMailboxSize`**: Verifica que el método `getMailboxSize()` devuelve el objeto `MailboxSize` correcto.    
- **`testGetMailboxStatus`**: Verifica que el método `getMailboxStatus()` devuelve el estado actual del buzón.
- **`testSetMailboxNumber`**: Valida que el setter de `mailboxNumber` actualiza el valor correctamente.
- **`testSetMailboxSize`**: Verifica que el método `setMailboxSize()` permite cambiar el tamaño del buzón.
- **`testSetMailboxStatus`**: Comprueba que `setMailboxStatus()` permite actualizar el estado del buzón.

[TEST-62 Testing Pull Request #37 - Buz 160 crear entidad mailbox](https://mabelrincon.atlassian.net/browse/TEST-62)