### PR TITLE
TEST-63 Testing AccessCodeStatusTest working

### DIFF
--- a/src/test/java/com/f5/buzon_inteligente_BE/accesscode/AccessCodeStatusTest.java
+++ b/src/test/java/com/f5/buzon_inteligente_BE/accesscode/AccessCodeStatusTest.java
@@ -1,0 +1,39 @@
+package com.f5.buzon_inteligente_BE.accesscode;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class AccessCodeStatusTest {
+    AccessCodeStatus accessCodeStatus;
+    @BeforeEach
+    void setUp() {
+        accessCodeStatus = new AccessCodeStatus("Entregado");
+    }
+    @Test
+    @DisplayName("test GetAccessCodeStatusId")
+    void testGetAccessCodeStatusId() {
+        assertThat(accessCodeStatus.getAccessCodeStatusId()).isNotNull();
+    }
+
+    @Test
+    @DisplayName("test GetAccessCodeStatusName")
+    void testGetAccessCodeStatusName() {
+        assertThat(accessCodeStatus.getAccessCodeStatusName()).isEqualTo("Entregado");
+    }
+
+    @Test
+    @DisplayName("test GetAccessCodes")
+    void testGetAccessCodes() {
+        assertThat(accessCodeStatus.getAccessCodes()).isNotNull();
+    }
+
+    @Test
+    @DisplayName("test SetAccessCodeStatusName")
+    void testSetAccessCodeStatusName() {
+        accessCodeStatus.setAccessCodeStatusName("Pendiente");
+        assertThat(accessCodeStatus.getAccessCodeStatusName()).isEqualTo("Pendiente");
+    }
+}


### PR DESCRIPTION
Se ha añadido un test específico para el campo `locker` de la entidad `User`, asegurando que el método `getLocker()` funciona correctamente. Para ello, se ha creado una instancia de `Locker` en el `setUp()` del test y se ha asignado mediante reflexión.

**Cambios realizados:**

- Se ha creado una instancia de `Locker` dentro del método `setUp()` en `UserTest`.
- Se ha utilizado reflexión para asignar el objeto `locker` al campo privado `locker` de la clase `User`.
- Se ha añadido el test `testGetLocker()` que valida que el `getLocker()` devuelve correctamente el objeto `Locker` asignado.
- El resto de tests no se han modificado.

**Motivación:**  
Asegurar la cobertura del nuevo campo `locker` en la entidad `User` y verificar su correcta integración en la lógica existente.