### PR TITLE
Buz 110 actualizacion automatica de estado

### DIFF
--- a/src/main/java/com/f5/buzon_inteligente_BE/accesscode/AccesCodeController.java
+++ b/src/main/java/com/f5/buzon_inteligente_BE/accesscode/AccesCodeController.java
@@ -6,6 +6,7 @@ import java.util.stream.Collectors;
 import com.f5.buzon_inteligente_BE.accesscode.DTO.AccessCodeRequestDTO;
 import com.f5.buzon_inteligente_BE.accesscode.DTO.AccessCodeResponseDTO;
 import com.f5.buzon_inteligente_BE.accesscode.DTO.AccessCodeUpdateStatusRequestDTO;
+import com.f5.buzon_inteligente_BE.accesscode.DTO.AccessCodeUpdateStatusResponseDTO;
 
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -40,8 +41,10 @@ public class AccesCodeController {
         return ResponseEntity.ok(accessCodeDTOs);
     }
     @PutMapping("/{accessCodeId}")
-    public ResponseEntity<?> putMethodName(@PathVariable Long accessCodeId, @RequestBody AccessCodeUpdateStatusRequestDTO accessCodeRequestDTO) {
-        accessCodeService.updateAccessCodeStatus(accessCodeId, accessCodeRequestDTO);
-        return ResponseEntity.ok("Estado actualizado");
+    public ResponseEntity<AccessCodeUpdateStatusResponseDTO> putMethodName(@PathVariable Long accessCodeId, @RequestBody AccessCodeUpdateStatusRequestDTO accessCodeRequestDTO) {
+        AccessCode updatedAccessCode = accessCodeService.updateAccessCodeStatus(accessCodeId, accessCodeRequestDTO);
+        return new ResponseEntity<>(
+                AccessCodeUpdateStatusResponseDTO.fromEntities(updatedAccessCode),
+                HttpStatus.OK);
     }
 }

--- a/src/main/java/com/f5/buzon_inteligente_BE/accesscode/AccesCodeController.java
+++ b/src/main/java/com/f5/buzon_inteligente_BE/accesscode/AccesCodeController.java
@@ -5,10 +5,12 @@ import java.util.stream.Collectors;
 
 import com.f5.buzon_inteligente_BE.accesscode.DTO.AccessCodeRequestDTO;
 import com.f5.buzon_inteligente_BE.accesscode.DTO.AccessCodeResponseDTO;
+import com.f5.buzon_inteligente_BE.accesscode.DTO.AccessCodeUpdateStatusRequestDTO;
 
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
+
 
 @RestController
 @RequestMapping("/api/accesscode")
@@ -36,5 +38,10 @@ public class AccesCodeController {
                 .map(AccessCodeResponseDTO::fromEntities)
                 .collect(Collectors.toList());
         return ResponseEntity.ok(accessCodeDTOs);
+    }
+    @PutMapping("/{accessCodeId}")
+    public ResponseEntity<?> putMethodName(@PathVariable Long accessCodeId, @RequestBody AccessCodeUpdateStatusRequestDTO accessCodeRequestDTO) {
+        accessCodeService.updateAccessCodeStatus(accessCodeId, accessCodeRequestDTO);
+        return ResponseEntity.ok("Estado actualizado");
     }
 }

--- a/src/main/java/com/f5/buzon_inteligente_BE/accesscode/AccessCode.java
+++ b/src/main/java/com/f5/buzon_inteligente_BE/accesscode/AccessCode.java
@@ -8,8 +8,6 @@ import java.time.LocalDateTime;
 
 import com.f5.buzon_inteligente_BE.profile.Profile;
 import com.f5.buzon_inteligente_BE.parcel.Parcel;
-import com.f5.buzon_inteligente_BE.accesscode.AccessCodeStatus;
-
 @Entity
 @Table(name = "access_codes")
 public class AccessCode implements Serializable {

--- a/src/main/java/com/f5/buzon_inteligente_BE/accesscode/AccessCodeController.java
+++ b/src/main/java/com/f5/buzon_inteligente_BE/accesscode/AccessCodeController.java
@@ -41,7 +41,7 @@ public class AccessCodeController {
         return ResponseEntity.ok(accessCodeDTOs);
     }
     @PutMapping("/{accessCodeId}")
-    public ResponseEntity<AccessCodeUpdateStatusResponseDTO> putMethodName(@PathVariable Long accessCodeId, @RequestBody AccessCodeUpdateStatusRequestDTO accessCodeRequestDTO) {
+    public ResponseEntity<AccessCodeUpdateStatusResponseDTO> setAccessCodeStatusId(@PathVariable Long accessCodeId, @RequestBody AccessCodeUpdateStatusRequestDTO accessCodeRequestDTO) {
         AccessCode updatedAccessCode = accessCodeService.updateAccessCodeStatus(accessCodeId, accessCodeRequestDTO);
         return new ResponseEntity<>(
                 AccessCodeUpdateStatusResponseDTO.fromEntities(updatedAccessCode),

--- a/src/main/java/com/f5/buzon_inteligente_BE/accesscode/AccessCodeController.java
+++ b/src/main/java/com/f5/buzon_inteligente_BE/accesscode/AccessCodeController.java
@@ -15,11 +15,11 @@ import org.springframework.web.bind.annotation.*;
 
 @RestController
 @RequestMapping("/api/accesscode")
-public class AccesCodeController {
+public class AccessCodeController {
 
     private final AccessCodeService accessCodeService;
 
-    public AccesCodeController(AccessCodeService accessCodeService) {
+    public AccessCodeController(AccessCodeService accessCodeService) {
         this.accessCodeService = accessCodeService;
     }
 

--- a/src/main/java/com/f5/buzon_inteligente_BE/accesscode/AccessCodeService.java
+++ b/src/main/java/com/f5/buzon_inteligente_BE/accesscode/AccessCodeService.java
@@ -95,7 +95,7 @@ public class AccessCodeService {
             accessCode.setLocked(true);
         }
         if (accessCodeStatus.getAccessCodeStatusId() == 6 || accessCodeStatus.getAccessCodeStatusId() == 7) {
-            //mailboxService.updateMailboxStatus(accessCodeRequestDTO.getMailboxId(), "FREE");
+            mailboxService.updateMailboxStatus(accessCodeRequestDTO.getMailboxId(), "FREE");
         }
 
         accessCode.setUpdateOn(LocalDateTime.now());

--- a/src/main/java/com/f5/buzon_inteligente_BE/accesscode/AccessCodeService.java
+++ b/src/main/java/com/f5/buzon_inteligente_BE/accesscode/AccessCodeService.java
@@ -1,9 +1,11 @@
 package com.f5.buzon_inteligente_BE.accesscode;
 
 import com.f5.buzon_inteligente_BE.accesscode.DTO.AccessCodeRequestDTO;
+import com.f5.buzon_inteligente_BE.accesscode.DTO.AccessCodeUpdateStatusRequestDTO;
 
 import com.f5.buzon_inteligente_BE.profile.Profile;
 import com.f5.buzon_inteligente_BE.profile.ProfileRepository;
+
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -53,5 +55,22 @@ public class AccessCodeService {
     @Transactional(readOnly = true)
     public List<AccessCode> getAccessCodesByProfileId(Long profileId) {
         return accessCodeRepository.findAllByProfile_Id(profileId);
+    }
+
+    public void updateAccessCodeStatus(Long accessCodeId, AccessCodeUpdateStatusRequestDTO accessCodeRequestDTO) {        
+        AccessCode accessCode = accessCodeRepository.findById(accessCodeId)
+                .orElseThrow(() -> new AccessCodeException("Código de acceso no encontrado con ID: " + accessCodeId));
+        
+        AccessCodeStatus accessCodeStatus = statusRepository.findById(accessCodeRequestDTO.getAccessCodeStatusId())
+                .orElseThrow(() -> new AccessCodeException("Estado no encontrado con ID: " + accessCodeRequestDTO.getAccessCodeStatusId()));
+        
+        if(accessCodeStatus.getAccessCodeStatusId() == 3) {
+            accessCode.setLocked(true);
+        }
+
+        accessCode.setUpdateOn(LocalDateTime.now());
+        
+        accessCode.setAccessCodeStatus(accessCodeStatus);
+        accessCodeRepository.save(accessCode);
     }
 }

--- a/src/main/java/com/f5/buzon_inteligente_BE/accesscode/DTO/AccessCodeUpdateStatusRequestDTO.java
+++ b/src/main/java/com/f5/buzon_inteligente_BE/accesscode/DTO/AccessCodeUpdateStatusRequestDTO.java
@@ -1,0 +1,25 @@
+package com.f5.buzon_inteligente_BE.accesscode.DTO;
+
+public class AccessCodeUpdateStatusRequestDTO {
+
+    private Long accessCodeId;
+    private Long accessCodeStatusId;
+
+    public Long getAccessCodeId() {
+        return accessCodeId;
+    }
+
+    public void setAccessCodeId(Long accessCodeId) {
+        this.accessCodeId = accessCodeId;
+    }
+
+    public Long getAccessCodeStatus(Long accessCodeStatusId) {    
+        return accessCodeStatusId;
+    }
+    public Long getAccessCodeStatusId() {
+        return accessCodeStatusId;
+    }
+    public void setAccessCodeStatus(Long accessCodeStatusId) {
+        this.accessCodeStatusId = accessCodeStatusId;
+    }
+}

--- a/src/main/java/com/f5/buzon_inteligente_BE/accesscode/DTO/AccessCodeUpdateStatusRequestDTO.java
+++ b/src/main/java/com/f5/buzon_inteligente_BE/accesscode/DTO/AccessCodeUpdateStatusRequestDTO.java
@@ -4,6 +4,7 @@ public class AccessCodeUpdateStatusRequestDTO {
 
     private Long accessCodeId;
     private Long accessCodeStatusId;
+    private Long mailboxId;
 
     public Long getAccessCodeId() {
         return accessCodeId;
@@ -21,5 +22,9 @@ public class AccessCodeUpdateStatusRequestDTO {
     }
     public void setAccessCodeStatus(Long accessCodeStatusId) {
         this.accessCodeStatusId = accessCodeStatusId;
+    }
+
+    public Long getMailboxId() {
+        return mailboxId;
     }
 }

--- a/src/main/java/com/f5/buzon_inteligente_BE/accesscode/DTO/AccessCodeUpdateStatusRequestDTO.java
+++ b/src/main/java/com/f5/buzon_inteligente_BE/accesscode/DTO/AccessCodeUpdateStatusRequestDTO.java
@@ -1,18 +1,8 @@
 package com.f5.buzon_inteligente_BE.accesscode.DTO;
 
 public class AccessCodeUpdateStatusRequestDTO {
-
-    private Long accessCodeId;
     private Long accessCodeStatusId;
     private Long mailboxId;
-
-    public Long getAccessCodeId() {
-        return accessCodeId;
-    }
-
-    public void setAccessCodeId(Long accessCodeId) {
-        this.accessCodeId = accessCodeId;
-    }
 
     public Long getAccessCodeStatus(Long accessCodeStatusId) {    
         return accessCodeStatusId;

--- a/src/main/java/com/f5/buzon_inteligente_BE/accesscode/DTO/AccessCodeUpdateStatusResponseDTO.java
+++ b/src/main/java/com/f5/buzon_inteligente_BE/accesscode/DTO/AccessCodeUpdateStatusResponseDTO.java
@@ -1,0 +1,53 @@
+package com.f5.buzon_inteligente_BE.accesscode.DTO;
+
+import java.time.LocalDateTime;
+
+import com.f5.buzon_inteligente_BE.accesscode.AccessCode;
+import com.f5.buzon_inteligente_BE.accesscode.AccessCodeStatus;
+
+public class AccessCodeUpdateStatusResponseDTO {
+
+    private Long accessCodeId;
+    private LocalDateTime updateOn;
+    private AccessCodeStatus accessCodeStatus;
+    private String userName;
+    private String userSurname;
+    private String userDni;
+
+    public AccessCodeUpdateStatusResponseDTO(AccessCode accessCode) {
+        this.accessCodeId = accessCode.getAccessCodeId();
+        this.updateOn = accessCode.getUpdateOn();
+        this.accessCodeStatus = accessCode.getAccessCodeStatus();
+        this.userName = accessCode.getProfile().getUser().getUserName();
+        this.userSurname = accessCode.getProfile().getUser().getUserSurname();
+        this.userDni = accessCode.getProfile().getUser().getUserDni();
+    }
+    
+    public Long getAccessCodeId() {
+        return accessCodeId;
+    }
+
+    public LocalDateTime getUpdateOn() {
+        return updateOn;
+    }
+
+    public AccessCodeStatus getAccessCodeStatus() {
+        return accessCodeStatus;
+    }
+
+    public String getUserName() {
+        return userName;
+    }
+
+    public String getUserSurname() {
+        return userSurname;
+    }
+
+    public String getUserDni() {
+        return userDni;
+    }
+
+    public static AccessCodeUpdateStatusResponseDTO fromEntities(AccessCode updatedAccessCode) {
+        return new AccessCodeUpdateStatusResponseDTO(updatedAccessCode);
+    }
+}

--- a/src/main/java/com/f5/buzon_inteligente_BE/mailbox/MailboxRepository.java
+++ b/src/main/java/com/f5/buzon_inteligente_BE/mailbox/MailboxRepository.java
@@ -1,6 +1,7 @@
 package com.f5.buzon_inteligente_BE.mailbox;
 
 import java.util.List;
+import java.util.Optional;
 
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -35,4 +36,6 @@ public interface MailboxRepository extends JpaRepository<Mailbox, Long> {
         @Param("mailboxStatusId") Long mailboxStatusId,
         Pageable pageable
     );
+
+    Optional<Mailbox>findById(Long mailboxId);
 }

--- a/src/main/java/com/f5/buzon_inteligente_BE/parcel/ParcelService.java
+++ b/src/main/java/com/f5/buzon_inteligente_BE/parcel/ParcelService.java
@@ -12,7 +12,8 @@ import com.f5.buzon_inteligente_BE.locker.Locker;
 import com.f5.buzon_inteligente_BE.mailbox.Mailbox;
 import com.f5.buzon_inteligente_BE.parcel.dto.ParcelResponseDTO;
 
-import jakarta.transaction.Transactional;
+
+import org.springframework.transaction.annotation.Transactional;
 
 @Service
 public class ParcelService {

--- a/src/main/resources/data.sql
+++ b/src/main/resources/data.sql
@@ -59,12 +59,12 @@ INSERT INTO access_code_status (access_code_status_name)
 VALUES
   ('Pendiente'),
   ('Entrega fallida'),
-  ('Entregado'),
-  ('Recogido'),
-  ('Pospuesto'),
-  ('No recogido'),
   ('Entregado parcialmente'),
-  ('Recogido parcialmente');
+  ('Entregado'),
+  ('Pospuesto'),
+  ('Recogido parcialmente'),
+  ('Recogido'),
+  ('No recogido');
 
 -- 10. Access Codes
 


### PR DESCRIPTION
Este Pull Request implementa todo el flujo necesario para actualizar el estado de un `AccessCode`, incluyendo la creación de DTOs para la petición y la respuesta, lógica condicional en el servicio, y ajustes en la base de datos.

#### ✅ Cambios principales:

- Se implementan los métodos necesarios para el flujo de actualizar estado del Access Code en el AccessCodeController `setAccessCodeStatusId` y AccessCodeService `updateAccessCodeStatus`

- **Creado `AccessCodeUpdateStatusRequestDTO`** para recibir los datos de actualización desde el frontend.
    
-  **Creado `AccessCodeUpdateStatusResponseDTO`**, que devuelve los datos del código de acceso actualizado:
    - Los datos personales del usuario (`nombre`, `apellidos`, `DNI`) **se excluyen** de la respuesta cuando el estado es **Pospuesto (5)**, **Recogido (6)** o **Recogido parcialmente (7)**.
        
- **Refactorizado `AccessCodeService`** para manejar la lógica de actualización y construir la respuesta adecuada.
    
-  **Actualizado `AccesCodeController`** para añadir el nuevo endpoint `PUT` con retorno de DTO personalizado.
    
-  **Reorganizado `data.sql`** para recolocar los valores de estado y mantener consistencia.
    
-  **Pequeños ajustes en `MailboxRepository`** para soportar la nueva lógica de buzones.
    
- **Limpieza de imports y código innecesario**.
    

---

###  Revisión:

- Se corrige nombre del controlador: `AccesCodeController` → `AccessCodeController` (línea 17).
- Se ha eliminado `accessCodeId` del `RequestDTO`, ya que se obtiene directamente del `@PathVariable`.
- Se corrige nombre de método en servicio a `setAccessCodeStatusId`