### PR TITLE
Buz 89 endpoint get access code vinculado a la credencial permanente

### DIFF
--- a/src/main/java/com/f5/buzon_inteligente_BE/accesscode/AccesCodeController.java
+++ b/src/main/java/com/f5/buzon_inteligente_BE/accesscode/AccesCodeController.java
@@ -5,6 +5,7 @@ import java.util.stream.Collectors;
 
 import com.f5.buzon_inteligente_BE.accesscode.DTO.AccessCodeRequestDTO;
 import com.f5.buzon_inteligente_BE.accesscode.DTO.AccessCodeResponseDTO;
+import com.f5.buzon_inteligente_BE.mailbox.Mailbox;
 
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -24,21 +25,34 @@ public class AccesCodeController {
     public ResponseEntity<AccessCodeResponseDTO> createAccessCode(
             @RequestBody AccessCodeRequestDTO accessCodeRequestDTO) {
         AccessCode createdAccessCode = accessCodeService.createAccessCode(accessCodeRequestDTO);
+
+
+        Mailbox mailbox = createdAccessCode.getParcels().isEmpty()
+                ? null
+                : createdAccessCode.getParcels().get(0).getMailbox();
+
         return new ResponseEntity<>(
-                AccessCodeResponseDTO.fromEntities(createdAccessCode),
+                AccessCodeResponseDTO.fromEntities(createdAccessCode, mailbox),
                 HttpStatus.CREATED);
     }
 
     @GetMapping("/profile/{profileId}")
     public ResponseEntity<List<AccessCodeResponseDTO>> getAccessCodesByProfile(@PathVariable Long profileId) {
         List<AccessCode> accessCodes = accessCodeService.getAccessCodesByProfileId(profileId);
+
         List<AccessCodeResponseDTO> accessCodeDTOs = accessCodes.stream()
-                .map(AccessCodeResponseDTO::fromEntities)
+                .map(ac -> {
+                    Mailbox mailbox = ac.getParcels().isEmpty()
+                            ? null
+                            : ac.getParcels().get(0).getMailbox();
+                    return AccessCodeResponseDTO.fromEntities(ac, mailbox);
+                })
                 .collect(Collectors.toList());
+
         return ResponseEntity.ok(accessCodeDTOs);
     }
 
-        @GetMapping("/credential/{permanentCredential}")
+    @GetMapping("/credential/{permanentCredential}")
     public ResponseEntity<?> getAccessCodesByCredential(@PathVariable String permanentCredential) {
         try {
             List<AccessCodeResponseDTO> accessCodes = accessCodeService.getAccessCodesByCredential(permanentCredential);

--- a/src/main/java/com/f5/buzon_inteligente_BE/accesscode/AccesCodeController.java
+++ b/src/main/java/com/f5/buzon_inteligente_BE/accesscode/AccesCodeController.java
@@ -37,4 +37,15 @@ public class AccesCodeController {
                 .collect(Collectors.toList());
         return ResponseEntity.ok(accessCodeDTOs);
     }
+
+        @GetMapping("/credential/{permanentCredential}")
+    public ResponseEntity<?> getAccessCodesByCredential(@PathVariable String permanentCredential) {
+        try {
+            List<AccessCodeResponseDTO> accessCodes = accessCodeService.getAccessCodesByCredential(permanentCredential);
+            return new ResponseEntity<>(accessCodes, HttpStatus.OK);
+        } catch (AccessCodeException e) {
+            return new ResponseEntity<>("Credencial no válida. Intente nuevamente o contacte soporte.",
+                    HttpStatus.UNAUTHORIZED);
+        }
+    }
 }

--- a/src/main/java/com/f5/buzon_inteligente_BE/accesscode/AccessCodeService.java
+++ b/src/main/java/com/f5/buzon_inteligente_BE/accesscode/AccessCodeService.java
@@ -2,6 +2,7 @@ package com.f5.buzon_inteligente_BE.accesscode;
 
 import com.f5.buzon_inteligente_BE.accesscode.DTO.AccessCodeRequestDTO;
 import com.f5.buzon_inteligente_BE.accesscode.DTO.AccessCodeResponseDTO;
+import com.f5.buzon_inteligente_BE.mailbox.Mailbox;
 import com.f5.buzon_inteligente_BE.profile.Profile;
 import com.f5.buzon_inteligente_BE.profile.ProfileRepository;
 import org.springframework.stereotype.Service;
@@ -55,7 +56,6 @@ public class AccessCodeService {
         return accessCodeRepository.findAllByProfile_Id(profileId);
     }
 
-  
     @Transactional(readOnly = true)
     public List<AccessCodeResponseDTO> getAccessCodesByCredential(String permanentCredential) {
         Profile profile = profileRepository.findByPermanentCredential(permanentCredential)
@@ -66,7 +66,10 @@ public class AccessCodeService {
                     String status = ac.getAccessCodeStatus().getAccessCodeStatusName();
                     return status.equalsIgnoreCase("Entregado") || status.equalsIgnoreCase("Entregado parcial");
                 })
-                .map(AccessCodeResponseDTO::fromEntities)
+                .map(ac -> {
+                    Mailbox mailbox = ac.getParcels().isEmpty() ? null : ac.getParcels().get(0).getMailbox();
+                    return AccessCodeResponseDTO.fromEntities(ac, mailbox);
+                })
                 .toList();
     }
 }

--- a/src/main/java/com/f5/buzon_inteligente_BE/accesscode/AccessCodeStatus.java
+++ b/src/main/java/com/f5/buzon_inteligente_BE/accesscode/AccessCodeStatus.java
@@ -8,6 +8,7 @@ import jakarta.persistence.*;
 
 @Entity
 @Table(name = "access_code_status")
+
 public class AccessCodeStatus implements Serializable {
     private static final long serialVersionUID = 1L;
 

--- a/src/main/java/com/f5/buzon_inteligente_BE/accesscode/DTO/AccessCodeResponseDTO.java
+++ b/src/main/java/com/f5/buzon_inteligente_BE/accesscode/DTO/AccessCodeResponseDTO.java
@@ -2,60 +2,44 @@ package com.f5.buzon_inteligente_BE.accesscode.DTO;
 
 import java.time.LocalDateTime;
 import com.f5.buzon_inteligente_BE.accesscode.AccessCode;
-import com.f5.buzon_inteligente_BE.accesscode.AccessCodeStatus;
 import com.f5.buzon_inteligente_BE.mailbox.Mailbox;
 
 public class AccessCodeResponseDTO {
     private Long accessCodeId;
     private String accessCode;
     private String accessCodeName;
-    private AccessCodeStatus accessCodeStatus;
+    private String accessCodeStatusName;
     private LocalDateTime updateOn;
-    private boolean isLocked = false;
+    private boolean isLocked;
     private int mailboxNumber;
 
-    public AccessCodeResponseDTO() {
-    }
-
-    public AccessCodeResponseDTO(Long accessCodeId, String code, String name, AccessCodeStatus accessCodeStatus, LocalDateTime updateOn,
-            boolean isLocked, int mailboxNumber) {
-        this.accessCode = code;
-        this.accessCodeName = name;
-        this.accessCodeStatus = accessCodeStatus;
-        this.updateOn = LocalDateTime.now();
+    public AccessCodeResponseDTO(
+            Long accessCodeId,
+            String accessCode,
+            String accessCodeName,
+            String accessCodeStatusName,
+            LocalDateTime updateOn,
+            boolean isLocked,
+            int mailboxNumber) {
+        this.accessCodeId = accessCodeId;
+        this.accessCode = accessCode;
+        this.accessCodeName = accessCodeName;
+        this.accessCodeStatusName = accessCodeStatusName;
+        this.updateOn = updateOn;
         this.isLocked = isLocked;
         this.mailboxNumber = mailboxNumber;
     }
 
-    public AccessCodeResponseDTO(Long accessCodeId, String code, String name, AccessCodeStatus accessCodeStatus,
-            LocalDateTime updateOn,
-            boolean isLocked) {
-        this.accessCode = code;
-        this.accessCodeName = name;
-        this.accessCodeStatus = accessCodeStatus;
-        this.updateOn = LocalDateTime.now();
-        this.isLocked = isLocked;
-    }
-
     public static AccessCodeResponseDTO fromEntities(AccessCode accessCode, Mailbox mailbox) {
+        int mailboxNumber = (mailbox != null) ? mailbox.getMailboxNumber() : -1;
         return new AccessCodeResponseDTO(
                 accessCode.getAccessCodeId(),
                 accessCode.getAccessCode(),
                 accessCode.getAccessCodeName(),
-                accessCode.getAccessCodeStatus(),
+                accessCode.getAccessCodeStatus().getAccessCodeStatusName(),
                 accessCode.getUpdateOn(),
                 accessCode.isLocked(),
-                mailbox.getMailboxNumber());
-    }
-
-    public static AccessCodeResponseDTO fromEntities(AccessCode accessCode) {
-        return new AccessCodeResponseDTO(
-                accessCode.getAccessCodeId(),
-                accessCode.getAccessCode(),
-                accessCode.getAccessCodeName(),
-                accessCode.getAccessCodeStatus(),
-                accessCode.getUpdateOn(),
-                accessCode.isLocked());
+                mailboxNumber);
     }
 
     public Long getAccessCodeId() {
@@ -82,12 +66,12 @@ public class AccessCodeResponseDTO {
         this.accessCodeName = accessCodeName;
     }
 
-    public AccessCodeStatus getAccessCodeStatus() {
-        return accessCodeStatus;
+    public String getAccessCodeStatusName() {
+        return accessCodeStatusName;
     }
 
-    public void setAccessCodeStatus(AccessCodeStatus accessCodeStatus) {
-        this.accessCodeStatus = accessCodeStatus;
+    public void setAccessCodeStatusName(String accessCodeStatusName) {
+        this.accessCodeStatusName = accessCodeStatusName;
     }
 
     public LocalDateTime getUpdateOn() {
@@ -102,8 +86,8 @@ public class AccessCodeResponseDTO {
         return isLocked;
     }
 
-    public void setLocked(boolean isLocked) {
-        this.isLocked = isLocked;
+    public void setLocked(boolean locked) {
+        isLocked = locked;
     }
 
     public int getMailboxNumber() {
@@ -113,5 +97,4 @@ public class AccessCodeResponseDTO {
     public void setMailboxNumber(int mailboxNumber) {
         this.mailboxNumber = mailboxNumber;
     }
-
 }

--- a/src/main/java/com/f5/buzon_inteligente_BE/accesscode/DTO/AccessCodeResponseDTO.java
+++ b/src/main/java/com/f5/buzon_inteligente_BE/accesscode/DTO/AccessCodeResponseDTO.java
@@ -4,6 +4,7 @@ import java.time.LocalDateTime;
 
 import com.f5.buzon_inteligente_BE.accesscode.AccessCode;
 import com.f5.buzon_inteligente_BE.accesscode.AccessCodeStatus;
+import com.f5.buzon_inteligente_BE.mailbox.Mailbox;
 
 public class AccessCodeResponseDTO {
     private Long accessCodeId; 
@@ -12,20 +13,43 @@ public class AccessCodeResponseDTO {
     private AccessCodeStatus accessCodeStatus;
     private LocalDateTime updateOn;
     private boolean isLocked = false;
+    private int mailboxNumber;
+
 
     public AccessCodeResponseDTO() {
     }
 
     public AccessCodeResponseDTO(Long accessCodeId, String code, String name, AccessCodeStatus accessCodeStatus, LocalDateTime updateOn,
-            boolean isLocked) {
+            boolean isLocked, int mailboxNumber) {
         this.accessCode = code;
         this.accessCodeName = name;
         this.accessCodeStatus = accessCodeStatus;
         this.updateOn = LocalDateTime.now();
         this.isLocked = isLocked;
+        this.mailboxNumber = mailboxNumber;
     }
 
-    public static AccessCodeResponseDTO fromEntities (AccessCode accessCode){
+    public AccessCodeResponseDTO(Long accessCodeId, String code, String name, AccessCodeStatus accessCodeStatus, LocalDateTime updateOn,
+    boolean isLocked) {
+this.accessCode = code;
+this.accessCodeName = name;
+this.accessCodeStatus = accessCodeStatus;
+this.updateOn = LocalDateTime.now();
+this.isLocked = isLocked;
+}
+
+    public static AccessCodeResponseDTO fromEntities (AccessCode accessCode, Mailbox mailbox) {
+        return new AccessCodeResponseDTO(
+            accessCode.getAccessCodeId(),
+            accessCode.getAccessCode(),
+            accessCode.getAccessCodeName(),
+            accessCode.getAccessCodeStatus(),
+            accessCode.getUpdateOn(),
+            accessCode.isLocked(),
+            mailbox.getMailboxNumber()
+        );
+    }
+    public static AccessCodeResponseDTO fromEntities (AccessCode accessCode) {
         return new AccessCodeResponseDTO(
             accessCode.getAccessCodeId(),
             accessCode.getAccessCode(),
@@ -35,6 +59,7 @@ public class AccessCodeResponseDTO {
             accessCode.isLocked()
         );
     }
+
     public Long getAccessCodeId() {
         return accessCodeId;
     }
@@ -81,6 +106,13 @@ public class AccessCodeResponseDTO {
     public void setLocked(boolean isLocked) {
         this.isLocked = isLocked;
     }
-
     
+    public int getMailboxNumber() {
+        return mailboxNumber;
+    }
+
+    public void setMailboxNumber(int mailboxNumber) {
+        this.mailboxNumber = mailboxNumber;
+}
+
 }

--- a/src/main/java/com/f5/buzon_inteligente_BE/config/SecurityConfig.java
+++ b/src/main/java/com/f5/buzon_inteligente_BE/config/SecurityConfig.java
@@ -48,6 +48,7 @@ public class SecurityConfig {
             .requestMatchers(AntPathRequestMatcher.antMatcher("/api/auth/**")).permitAll()
             .requestMatchers(AntPathRequestMatcher.antMatcher("/api/mailboxes/**")).permitAll()
             .requestMatchers(AntPathRequestMatcher.antMatcher("/user/**")).authenticated()
+            .requestMatchers("/api/accesscode/credential/**").permitAll()
             .anyRequest().authenticated())
             .addFilterBefore(new JwtAuthenticationFilter(jwtUtils, customUserDetailsService, logoutService),
             UsernamePasswordAuthenticationFilter.class);

--- a/src/main/resources/data.sql
+++ b/src/main/resources/data.sql
@@ -55,18 +55,27 @@ VALUES
   (102, 2, 'CRED-FREDDIE01');
 
 -- 9. Access Code Status
-INSERT INTO access_code_status (access_code_status_name)
-VALUES
-  ('Pendiente'),
-  ('Entrega fallida'),
-  ('Entregado'),
-  ('Recogido'),
-  ('Pospuesto'),
-  ('No recogido'),
-  ('Entregado parcialmente'),
-  ('Recogido parcialmente');
+INSERT INTO access_code_status (access_code_status_id, access_code_status_name) VALUES
+  (1, 'Pendiente'),
+  (2, 'Entrega fallida'),
+  (3, 'Entregado'),
+  (4, 'Recogido'),
+  (5, 'Pospuesto'),
+  (6, 'No recogido'),
+  (7, 'Entregado parcialmente'),
+  (8, 'Recogido parcialmente');
 
 -- 10. Access Codes
 
+INSERT INTO access_codes (access_code, access_code_name, profile_id, access_code_status_id, update_on, is_locked)
+VALUES 
+  ('ABCD1234', 'Paquete Amazon', 101, 3, CURRENT_TIMESTAMP, false),
+  ('XYZ98765', 'Pedido Shein', 102, 7, CURRENT_TIMESTAMP, false);
+
 
 -- 11. Parcels
+
+INSERT INTO parcels (access_code_id, mailbox_id, delivery_date, alarm_date, deadline_date)
+VALUES 
+  (1, 1, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP + INTERVAL 1 HOUR, CURRENT_TIMESTAMP + INTERVAL 24 HOUR),
+  (2, 2, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP + INTERVAL 2 HOUR, CURRENT_TIMESTAMP + INTERVAL 36 HOUR);


### PR DESCRIPTION
[Jira](https://grigorivladimiro.atlassian.net/browse/BUZ-89)

Se creó el endpoint público GET /api/accesscode/credential/{permanentCredential} para que el sistema del locker pueda consultar los códigos de acceso vinculados a una credencial.

- [ ] El endpoint filtra y devuelve únicamente los AccessCode con estado "Entregado" o "Entregado parcialmente".

- [ ] Se incluye el mailboxNumber en el DTO de respuesta, a través del Parcel vinculado a cada código.

- [ ] Se actualizó la configuración de seguridad (SecurityConfig) para permitir públicamente únicamente esta ruta, sin afectar la protección del resto de los endpoints del controlador AccessCodeController.

- [ ] Se actualizaron datos de prueba en data.sql para incluir:

Estados access_code_status con IDs explícitos.

Dos AccessCodes con estados válidos y vinculados a perfiles.

Parcels asociadas con sus respectivos Mailboxes, con fechas correctas para MySQL
![image](https://github.com/user-attachments/assets/d9b9bfc6-5b41-4f58-b4b9-f676ecce71a3)
